### PR TITLE
Better detect the LGPL

### DIFF
--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -8,7 +8,7 @@ module Licensee
       PREFERRED_EXT_REGEX = /\.#{Regexp.union(PREFERRED_EXT)}\z/.freeze
 
       # Regex to match any extension except .spdx or .header
-      OTHER_EXT_REGEX = %r{\.(?!spdx|header|gemspec)[^./]+\z}i.freeze
+      OTHER_EXT_REGEX = %r{(\.(?!spdx|header|gemspec)[^./]+)+\z}i.freeze
 
       # Regex to match, LICENSE, LICENCE, unlicense, etc.
       LICENSE_REGEX = /(un)?licen[sc]e/i.freeze

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -68,7 +68,7 @@ module Licensee
       end
 
       def lgpl?
-        LicenseFile.lesser_gpl_score(filename) == 1 && license && license.lgpl?
+        license && license.lgpl?
       end
 
       def gpl?
@@ -85,11 +85,6 @@ module Licensee
 
       def self.name_score(filename)
         FILENAME_REGEXES.find { |regex, _| filename =~ regex }[1]
-      end
-
-      # case-insensitive block to determine if the given file is LICENSE.lesser
-      def self.lesser_gpl_score(filename)
-        filename.casecmp('copying.lesser').zero? ? 1 : 0
       end
     end
   end

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe Licensee::ProjectFiles::LicenseFile do
       'LICENCE.docs'       => 0.80,
       'copying.image'      => 0.75,
       'COPYRIGHT.go'       => 0.75,
+      'COPYING.LESSER'     => 0.75,
+      'COPYING.LESSER.md'  => 0.75,
       'LICENSE-MIT'        => 0.70,
       'LICENSE_1_0.txt'    => 0.70,
       'COPYING-GPL'        => 0.65,

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -93,24 +93,6 @@ RSpec.describe Licensee::ProjectFiles::LicenseFile do
       end
     end
 
-    context 'LGPL scoring' do
-      {
-        'COPYING.lesser' => 1,
-        'copying.lesser' => 1,
-        'license.lesser' => 0,
-        'LICENSE.md'     => 0,
-        'FOO.md'         => 0
-      }.each do |filename, expected|
-        context "a file named #{filename}" do
-          let(:score) { described_class.lesser_gpl_score(filename) }
-
-          it 'scores the file' do
-            expect(score).to eql(expected)
-          end
-        end
-      end
-    end
-
     context 'preferred license regex' do
       %w[md markdown txt].each do |ext|
         it "matches .#{ext}" do
@@ -201,35 +183,6 @@ Creative Commons Attribution-NonCommercial 4.0
       it "knows it's a potential false positive" do
         expect(subject.content).to match(regex)
         expect(subject).to be_a_potential_false_positive
-      end
-    end
-  end
-
-  context 'LGPL' do
-    let(:lgpl) { Licensee::License.find('lgpl-3.0') }
-    let(:content) { sub_copyright_info(lgpl) }
-
-    context 'with a COPYING.lesser file' do
-      let(:filename) { 'COPYING.lesser' }
-
-      it 'knows when a license file is LGPL' do
-        expect(subject).to be_lgpl
-      end
-
-      context 'with non-lgpl content' do
-        let(:content) { sub_copyright_info(mit) }
-
-        it 'is not lgpl' do
-          expect(subject).to_not be_lgpl
-        end
-      end
-    end
-
-    context 'with a different file name' do
-      let(:filename) { 'COPYING' }
-
-      it 'is not lgpl' do
-        expect(subject).to_not be_lgpl
       end
     end
   end


### PR DESCRIPTION
This makes two changes to better support the LGPL, from the discussion in #287.

1. License files are now allowed to have multiple extensions, e.g. `COPYING.LESSER.md`.
2. The LGPL license file is no longer required to be named `COPYING.LESSER`.

The first change has implications beyond the LGPL, but I can't think of any negative consequences.

The second change only removes code, and I don't think I need to add any new tests for this change. The old `LGPL` context in the `LicenseFile` spec is removed because it's all about handling a file specifically named `COPYING.LESSER`. The `lgpl` context in the `Project` spec ensures that the LGPL takes precedence when license files for both the GPL and LGPL are present, which I believe is a sufficient test.

Together these close #287.