### PR TITLE
ensure confidence and similarity return same scores

### DIFF
--- a/lib/licensee/matchers/dice.rb
+++ b/lib/licensee/matchers/dice.rb
@@ -51,7 +51,7 @@ module Licensee
 
       # Confidence that the matched license is a match
       def confidence
-        @confidence ||= match ? file.similarity(match) : 0
+        @confidence ||= match ? match.similarity(file) : 0
       end
 
       private

--- a/spec/vendored_license_spec.rb
+++ b/spec/vendored_license_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe 'vendored licenses' do
         expect(content).to be_detected_as(license)
       end
 
+      it 'confidence and similarity scores are euqal' do
+        expect(license_file.confidence).to eq(license.similarity(license_file))
+      end
+
       it 'has a cached content hash' do
         expect(expected_hash).to_not be_nil, hash_change_msg
       end


### PR DESCRIPTION
This is a little followup to #388 -- since that does some preprocessing which only affects license templates (with fill in fields) and assumes it's operating on a candidate license (template), it's necessary to invoke similarity on the template with the content being detected as the argument. The confidence method was doing it in the reverse, which caused confidence to not equal similarity for licenses with fill in fields in the license body.