### PR TITLE
Loosen dependency on octokit to allow later minor versions

### DIFF
--- a/lib/licensee/commands/diff.rb
+++ b/lib/licensee/commands/diff.rb
@@ -49,7 +49,9 @@ class LicenseeCLI < Thor
   end
 
   def expected_license
-    @expected_license ||= Licensee::License.find options[:license] if options[:license]
+    if options[:license]
+      @expected_license ||= Licensee::License.find options[:license]
+    end
     return @expected_license if @expected_license
 
     if options[:license]

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -187,7 +187,7 @@ module Licensee
     end
 
     def self.format_percent(float)
-      "#{format('%.2f', float)}%"
+      "#{format('%<float>.2f', float: float)}%"
     end
 
     def self.title_regex

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.executables << 'licensee'
 
   gem.add_dependency('dotenv', '~> 2.0')
-  gem.add_dependency('octokit', '~> 4.8.0')
+  gem.add_dependency('octokit', '~> 4.8')
   gem.add_dependency('reverse_markdown', '~> 1.0')
   gem.add_dependency('rugged', '~> 0.24')
   gem.add_dependency('thor', '~> 0.19')

--- a/spec/fixtures/detect.json
+++ b/spec/fixtures/detect.json
@@ -86,7 +86,6 @@
   ],
   "matched_files": [
     {
-      "attribution": "Copyright (c) 2014-2017 Ben Balter",
       "filename": "LICENSE.md",
       "content": "MIT License\n\nCopyright (c) 2014-2017 Ben Balter\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n",
       "content_hash": "d64f3bb4282a97b37454b5bb96a8a264a3363dc3",
@@ -95,19 +94,20 @@
         "name": "exact",
         "confidence": 100
       },
-      "matched_license": "MIT"
+      "matched_license": "MIT",
+      "attribution": "Copyright (c) 2014-2017 Ben Balter"
     },
     {
-      "attribution": null,
       "filename": "licensee.gemspec",
-      "content": "# frozen_string_literal: true\n\nrequire File.expand_path('lib/licensee/version', __dir__)\n\nGem::Specification.new do |gem|\n  gem.name    = 'licensee'\n  gem.version = Licensee::VERSION\n\n  gem.summary = 'A Ruby Gem to detect open source project licenses'\n  gem.description = <<-DESC\n    Licensee automates the process of reading LICENSE files and\n    compares their contents to known licenses using a fancy maths.\n  DESC\n\n  gem.authors  = ['Ben Balter']\n  gem.email    = 'ben.balter@github.com'\n  gem.homepage = 'https://github.com/benbalter/licensee'\n  gem.license  = 'MIT'\n\n  gem.bindir = 'bin'\n  gem.executables << 'licensee'\n\n  gem.add_dependency('dotenv', '~> 2.0')\n  gem.add_dependency('octokit', '~> 4.8.0')\n  gem.add_dependency('reverse_markdown', '~> 1.0')\n  gem.add_dependency('rugged', '~> 0.24')\n  gem.add_dependency('thor', '~> 0.19')\n\n  gem.add_development_dependency('mustache', '>= 0.9', '< 2.0')\n  gem.add_development_dependency('pry', '~> 0.9')\n  gem.add_development_dependency('rake', '~> 10.3')\n  gem.add_development_dependency('rspec', '~> 3.5')\n  gem.add_development_dependency('rubocop', '~> 0.69')\n  gem.add_development_dependency('simplecov', '~> 0.16')\n  gem.add_development_dependency('webmock', '~> 3.1')\n\n  gem.required_ruby_version = '> 2.3'\n\n  # ensure the gem is built out of versioned files\n  gem.files = Dir[\n    'Rakefile',\n    '{bin,lib,man,test,vendor,spec}/**/*',\n    'README*', 'LICENSE*'\n  ] & `git ls-files -z`.split(\"\\0\")\nend\n",
+      "content": "# frozen_string_literal: true\n\nrequire File.expand_path('lib/licensee/version', __dir__)\n\nGem::Specification.new do |gem|\n  gem.name    = 'licensee'\n  gem.version = Licensee::VERSION\n\n  gem.summary = 'A Ruby Gem to detect open source project licenses'\n  gem.description = <<-DESC\n    Licensee automates the process of reading LICENSE files and\n    compares their contents to known licenses using a fancy maths.\n  DESC\n\n  gem.authors  = ['Ben Balter']\n  gem.email    = 'ben.balter@github.com'\n  gem.homepage = 'https://github.com/benbalter/licensee'\n  gem.license  = 'MIT'\n\n  gem.bindir = 'bin'\n  gem.executables << 'licensee'\n\n  gem.add_dependency('dotenv', '~> 2.0')\n  gem.add_dependency('octokit', '~> 4.8')\n  gem.add_dependency('reverse_markdown', '~> 1.0')\n  gem.add_dependency('rugged', '~> 0.24')\n  gem.add_dependency('thor', '~> 0.19')\n\n  gem.add_development_dependency('mustache', '>= 0.9', '< 2.0')\n  gem.add_development_dependency('pry', '~> 0.9')\n  gem.add_development_dependency('rake', '~> 10.3')\n  gem.add_development_dependency('rspec', '~> 3.5')\n  gem.add_development_dependency('rubocop', '~> 0.69')\n  gem.add_development_dependency('simplecov', '~> 0.16')\n  gem.add_development_dependency('webmock', '~> 3.1')\n\n  gem.required_ruby_version = '> 2.3'\n\n  # ensure the gem is built out of versioned files\n  gem.files = Dir[\n    'Rakefile',\n    '{bin,lib,man,test,vendor,spec}/**/*',\n    'README*', 'LICENSE*'\n  ] & `git ls-files -z`.split(\"\\0\")\nend\n",
       "content_hash": null,
       "content_normalized": null,
       "matcher": {
         "name": "gemspec",
         "confidence": 90
       },
-      "matched_license": "MIT"
+      "matched_license": "MIT",
+      "attribution": null
     }
   ]
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,7 +103,7 @@ def git_init(path)
 end
 
 def format_percent(float)
-  "#{format('%.2f', float)}%"
+  "#{format('%<float>.2f', float: float)}%"
 end
 
 def meta_fields


### PR DESCRIPTION
It seems unnecessary to lock to `octokit` `4.8.x`, so this commit allows octokit 4.x.

/cc @benbalter for review.