### PR TITLE
Update vendored licenses

### DIFF
--- a/script/vendor-licenses
+++ b/script/vendor-licenses
@@ -3,4 +3,5 @@
 VENDOR_DIR=vendor/choosealicense.com
 rm -Rf $VENDOR_DIR
 mkdir -p $VENDOR_DIR
-curl -L https://api.github.com/repos/github/choosealicense.com/tarball |tar xf - --include='*/_data' --include='*/_licenses' --strip-components=1 -C $VENDOR_DIR
+[[ $(tar --version | head -n 1) =~ bsdtar.* ]] || taropt='--wildcards'
+curl -L https://api.github.com/repos/github/choosealicense.com/tarball |tar zxf - -C $VENDOR_DIR $taropt --strip-components=1 */_data/* */_licenses/*

--- a/spec/fixtures/license-hashes.json
+++ b/spec/fixtures/license-hashes.json
@@ -7,6 +7,7 @@
   "bsd-2-clause": "59f0099ff04225daf184db3fe55e478256133b1a",
   "bsd-3-clause": "fa22c672927af9c7334874561198799cbf4bdf31",
   "bsd-3-clause-clear": "251d4599b622d2a87b2c4bb21dfacd438c048466",
+  "bsd-4-clause": "c31a46c2b8764b63d73332c5e9e11f109dadee45",
   "bsl-1.0": "ca8f916d00c234719956e932061f192abb2d5bf9",
   "cc-by-4.0": "899872bc08626e6cf154dcf9e08ff0de82c9b3db",
   "cc-by-sa-4.0": "d11590d97684231d5358252e0cc97373d62ec4f1",

--- a/spec/licensee/license_spec.rb
+++ b/spec/licensee/license_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Licensee::License do
-  let(:license_count) { 39 }
-  let(:hidden_license_count) { 26 }
+  let(:license_count) { 40 }
+  let(:hidden_license_count) { 27 }
   let(:featured_license_count) { 3 }
   let(:pseudo_license_count) { 2 }
   let(:non_featured_license_count) do

--- a/spec/licensee/rule_spec.rb
+++ b/spec/licensee/rule_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Licensee::Rule do
   end
 
   it 'loads all rules' do
-    expect(described_class.all.count).to eql(16)
+    expect(described_class.all.count).to eql(17)
     rule = described_class.all.first
     expect(rule).to be_a(described_class)
     expect(rule.tag).to eql('commercial-use')

--- a/spec/licensee_spec.rb
+++ b/spec/licensee_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Licensee do
   let(:project_path) { fixture_path('mit') }
   let(:license_path) { fixture_path('mit/LICENSE.txt') }
   let(:mit_license) { Licensee::License.find('mit') }
-  let(:hidden_license_count) { 39 }
+  let(:hidden_license_count) { 40 }
 
   it 'exposes licenses' do
     expect(described_class.licenses).to be_an(Array)

--- a/vendor/choosealicense.com/_data/rules.yml
+++ b/vendor/choosealicense.com/_data/rules.yml
@@ -19,6 +19,9 @@ conditions:
 - description: A copy of the license and copyright notice must be included with the software.
   label: License and copyright notice
   tag: include-copyright
+- description: A copy of the license and copyright notice must be included with the software in source form, but is not required for binaries.
+  label: License and copyright notice for source
+  tag: include-copyright--source
 - description: Changes made to the code must be documented.
   label: State changes
   tag: document-changes

--- a/vendor/choosealicense.com/_licenses/bsd-4-clause.txt
+++ b/vendor/choosealicense.com/_licenses/bsd-4-clause.txt
@@ -1,0 +1,61 @@
+---
+title: BSD 4-Clause "Original" or "Old" License
+spdx-id: BSD-4-Clause
+
+description: A permissive license similar to the <a href="/licenses/bsd-3-clause/">BSD 3-Clause License</a>, but with an "advertising clause" that requires an acknowledgment of the original source in all advertising material.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
+
+using:
+  - Yosemite Blockchain: https://github.com/YosemiteLabs/yosemite-public-blockchain/blob/master/LICENSE
+  - querybuilder: https://github.com/pwolfgang/querybuilder/blob/master/LICENSE
+  - PMSPAUR-public: https://github.com/ArthurGodet/PMSPAUR-public/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - private-use
+
+conditions:
+  - include-copyright
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+BSD 4-Clause License
+
+Copyright (c) [year], [fullname]
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. All advertising materials mentioning features or use of this software must
+   display the following acknowledgement:
+     This product includes software developed by [project].
+
+4. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/choosealicense.com/_licenses/bsl-1.0.txt
+++ b/vendor/choosealicense.com/_licenses/bsl-1.0.txt
@@ -9,6 +9,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: Boost recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the [Boost Software License FAQ](https://www.boost.org/users/license.html#FAQ).
 
 using:
+  - Boost: https://github.com/boostorg/boost/blob/master/LICENSE_1_0.txt
+  - Catch2: https://github.com/catchorg/Catch2/blob/master/LICENSE.txt
+  - DMD: https://github.com/dlang/dmd/blob/master/LICENSE.txt
 
 permissions:
   - commercial-use
@@ -17,7 +20,7 @@ permissions:
   - private-use
 
 conditions:
-  - include-copyright
+  - include-copyright--source
 
 limitations:
   - liability

--- a/vendor/choosealicense.com/_licenses/cc-by-4.0.txt
+++ b/vendor/choosealicense.com/_licenses/cc-by-4.0.txt
@@ -7,6 +7,9 @@ description: Permits almost any use subject to providing credit and license noti
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to solely supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by/4.0/'>canonical URL for the license</a>.
 
 using:
+  - caniuse: https://github.com/Fyrd/caniuse/blob/master/LICENSE
+  - WHATWG HTML standard: https://github.com/whatwg/html/blob/master/LICENSE
+  - Kubernetes documentation: https://github.com/kubernetes/website/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/cc-by-sa-4.0.txt
+++ b/vendor/choosealicense.com/_licenses/cc-by-sa-4.0.txt
@@ -7,6 +7,9 @@ description: Similar to <a href='/licenses/cc-by-4.0/'>CC-BY-4.0</a> but require
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to solely supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by-sa/4.0/'>canonical URL for the license</a>.
 
 using:
+  - Flight rules for Git: https://github.com/k88hudson/git-flight-rules/blob/master/LICENSE
+  - GitHub-Dark: https://github.com/StylishThemes/GitHub-Dark/blob/master/LICENSE
+  - Material Design Iconic Font: https://github.com/zavoloklom/material-design-iconic-font/blob/master/License.md
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/ofl-1.1.txt
+++ b/vendor/choosealicense.com/_licenses/ofl-1.1.txt
@@ -10,6 +10,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: This license doesn't require source provision, but recommends it. All files derived from OFL files must remain licensed under the OFL.
 
 using:
+  - FiraCode: https://github.com/tonsky/FiraCode/blob/master/LICENSE
+  - Noto fonts: https://github.com/googlefonts/noto-fonts/blob/master/LICENSE
+  - Fantasque Sans Mono: https://github.com/belluzj/fantasque-sans/blob/master/LICENSE.txt
 
 permissions:
   - private-use

--- a/vendor/choosealicense.com/_licenses/zlib.txt
+++ b/vendor/choosealicense.com/_licenses/zlib.txt
@@ -7,6 +7,9 @@ description: A short permissive license, compatible with GPL. Requires altered s
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
+  - GLFW: https://github.com/glfw/glfw/blob/master/LICENSE.md
+  - Portainer: https://github.com/portainer/portainer/blob/develop/LICENSE
+  - TinyXML-2: https://github.com/leethomason/tinyxml2/blob/master/LICENSE.txt
 
 permissions:
   - commercial-use
@@ -15,7 +18,7 @@ permissions:
   - private-use
 
 conditions:
-  - include-copyright
+  - include-copyright--source
   - document-changes
 
 limitations:


### PR DESCRIPTION
One [new (very old) license](https://github.com/github/choosealicense.com/pull/669) and one [new (refined) rule](https://github.com/github/choosealicense.com/pull/698) from choosealicense.com since last update. Other changes are only to the examples of use provided for most licenses.