### PR TITLE
Add matcher for NuGet license expressions in .nuspec files

### DIFF
--- a/lib/licensee/matchers.rb
+++ b/lib/licensee/matchers.rb
@@ -12,6 +12,7 @@ module Licensee
     autoload :Exact,     'licensee/matchers/exact'
     autoload :Gemspec,   'licensee/matchers/gemspec'
     autoload :NpmBower,  'licensee/matchers/npm_bower'
+    autoload :NuGet,     'licensee/matchers/nuget'
     autoload :Package,   'licensee/matchers/package'
     autoload :Reference, 'licensee/matchers/reference'
     autoload :Spdx,      'licensee/matchers/spdx'

--- a/lib/licensee/matchers/nuget.rb
+++ b/lib/licensee/matchers/nuget.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Licensee
+  module Matchers
+    class NuGet < Licensee::Matchers::Package
+      # While we could parse the nuspec file, prefer a lenient regex for speed and security.
+      # Moar parsing moar problems.
+      LICENSE_REGEX = %r{
+        <license\s*type\s*=\s*["']expression["']\s*>([a-z\-0-9\. +()]+)<\/license\s*>
+      }ix.freeze
+
+      LICENSE_URL_REGEX = %r{<licenseUrl>\s*(.*)\s*<\/licenseUrl>}i.freeze
+
+      NUGET_REGEX = %r{https?:\/\/licenses.nuget.org\/(.*)}i.freeze
+      OPENSOURCE_REGEX = %r{https?:\/\/(?:www\.)?opensource.org\/licenses\/(.*)}i.freeze
+      SPDX_REGEX = %r{https?:\/\/(?:www\.)?spdx.org\/licenses\/(.*?)(?:\.html|\.txt)?$}i.freeze
+      APACHE_REGEX = %r{https?:\/\/(?:www\.)?apache.org\/licenses\/(.*?)(?:\.html|\.txt)?$}i.freeze
+
+      private
+
+      def license_from_first_capture(url, pattern)
+        match = url.match(pattern)
+        match[1].downcase if match && match[1]
+      end
+
+      def license_from_url(url)
+        license_from_first_capture(url, NUGET_REGEX) ||
+          license_from_first_capture(url, OPENSOURCE_REGEX) ||
+          license_from_first_capture(url, SPDX_REGEX) ||
+          license_from_first_capture(url, APACHE_REGEX)&.gsub('license', 'apache')
+      end
+
+      def license_property
+        # Prefer the explicit <license type="expression"> element
+        match = @file.content.match LICENSE_REGEX
+        return match[1].downcase if match && match[1]
+
+        url_match = @file.content.match LICENSE_URL_REGEX
+        license_from_url(url_match[1]) if url_match && url_match[1]
+      end
+    end
+  end
+end

--- a/lib/licensee/project_files/package_manager_file.rb
+++ b/lib/licensee/project_files/package_manager_file.rb
@@ -7,7 +7,8 @@ module Licensee
       MATCHERS_EXTENSIONS = {
         '.gemspec' => [Matchers::Gemspec],
         '.json'    => [Matchers::NpmBower],
-        '.cabal'   => [Matchers::Cabal]
+        '.cabal'   => [Matchers::Cabal],
+        '.nuspec'  => [Matchers::NuGet]
       }.freeze
 
       # Hash of Filename => [possible matchers]
@@ -33,7 +34,7 @@ module Licensee
       end
 
       def self.name_score(filename)
-        return 1.0 if ['.gemspec', '.cabal'].include?(File.extname(filename))
+        return 1.0 if ['.gemspec', '.cabal', '.nuspec'].include?(File.extname(filename))
 
         FILENAMES_SCORES[filename] || 0.0
       end

--- a/spec/licensee/matchers/nu_get_matcher_spec.rb
+++ b/spec/licensee/matchers/nu_get_matcher_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Licensee::Matchers::NuGet do
+  subject { described_class.new(file) }
+
+  let(:content) { '<license type="expression">mit</license>' }
+  let(:file) { Licensee::ProjectFiles::LicenseFile.new(content, 'foo.nuspec') }
+  let(:mit) { Licensee::License.find('mit') }
+  let(:apache2) { Licensee::License.find('apache-2.0') }
+  let(:other) { Licensee::License.find('other') }
+
+  it 'matches' do
+    expect(subject.match).to eql(mit)
+  end
+
+  it 'has a confidence' do
+    expect(subject.confidence).to be(90)
+  end
+
+  {
+    'double quotes'      => '<license type="expression">mit</license>',
+    'single quotes'      => "<license type='expression'>mit</license>",
+    'whitespace'         => '<license  type = "expression" >mit</license >',
+    'leading whitespace' => ' <license type="expression">mit</license>'
+  }.each do |description, license_declaration|
+    context "with a #{description} license element" do
+      let(:content) { license_declaration }
+
+      it 'matches' do
+        expect(subject.match).to eql(mit)
+      end
+    end
+  end
+
+  context 'no license field' do
+    let(:content) { '<file>wrongelement</file>' }
+
+    it 'returns nil' do
+      expect(subject.match).to be_nil
+    end
+  end
+
+  context 'an unknown license' do
+    let(:content) { '<license type="expression">foo</license>' }
+
+    it 'returns other' do
+      expect(subject.match).to eql(other)
+    end
+  end
+
+  context 'a license expression' do
+    let(:content) { '<license type="expression">BSD-2-Clause OR MIT</license>' }
+
+    it 'returns other' do
+      expect(subject.match).to eql(other)
+    end
+  end
+
+  {
+    'nuget'            => '<licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>',
+    'nuget (http)'     => '<licenseUrl>http://licenses.nuget.org/Apache-2.0</licenseUrl>',
+    'opensource'       => '<licenseUrl>https://opensource.org/licenses/Apache-2.0</licenseUrl>',
+    'opensource (www)' => '<licenseUrl>http://www.opensource.org/licenses/Apache-2.0</licenseUrl>',
+    'spdx'             => '<licenseUrl>https://spdx.org/licenses/Apache-2.0</licenseUrl>',
+    'spdx (www)'       => '<licenseUrl>http://www.spdx.org/licenses/Apache-2.0</licenseUrl>',
+    'spdx (html)'      => '<licenseUrl>https://spdx.org/licenses/Apache-2.0.html</licenseUrl>',
+    'spdx (txt)'       => '<licenseUrl>https://spdx.org/licenses/Apache-2.0.txt</licenseUrl>'
+  }.each do |description, license_declaration|
+    context "with a #{description} licenseUrl element containing SPDX" do
+      let(:content) { license_declaration }
+
+      it 'matches' do
+        expect(subject.match).to eql(apache2)
+      end
+    end
+  end
+
+  {
+    '2.0 (https)'    => '<licenseUrl>https://apache.org/licenses/LICENSE-2.0</licenseUrl>',
+    '2.0 (http/www)' => '<licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>',
+    '2.0 (txt)'      => '<licenseUrl>https://apache.org/licenses/LICENSE-2.0.txt</licenseUrl>'
+  }.each do |description, license_declaration|
+    context "with an apache.org #{description} licenseUrl element" do
+      let(:content) { license_declaration }
+
+      it 'matches' do
+        expect(subject.match).to eql(apache2)
+      end
+    end
+  end
+end

--- a/spec/licensee/project_files/package_info_spec.rb
+++ b/spec/licensee/project_files/package_info_spec.rb
@@ -71,5 +71,13 @@ RSpec.describe Licensee::ProjectFiles::PackageManagerFile do
         expect(possible_matchers).to eql([Licensee::Matchers::Cran])
       end
     end
+
+    context 'with nuspec file' do
+      let(:filename) { 'foo.nuspec' }
+
+      it 'returns the NuGet matcher' do
+        expect(possible_matchers).to eql([Licensee::Matchers::NuGet])
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds support for matching NuGet license expressions (https://docs.microsoft.com/en-us/nuget/reference/nuspec#license).

Note that the `license` element also supports pointing to a file instead of an expression; licensee should already find the vast majority (but not all) of these though.