### PR TITLE
Modify the long text penality to fix Vim license detection

### DIFF
--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -132,7 +132,7 @@ module Licensee
       overlap = (wordset_fieldless & other.wordset).size
       total = wordset_fieldless.size + other.wordset.size -
               fields_normalized_set.size
-      (overlap * 200.0) / (total + length_delta(other) / 10)
+      (overlap * 200.0) / (total + length_delta(other) / 13)
     end
 
     # SHA1 of the normalized content

--- a/spec/licensee/matchers/dice_matcher_spec.rb
+++ b/spec/licensee/matchers/dice_matcher_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Licensee::Matchers::Dice do
   let(:lgpl) { Licensee::License.find('lgpl-2.1') }
   let(:cc_by) { Licensee::License.find('cc-by-4.0') }
   let(:cc_by_sa) { Licensee::License.find('cc-by-sa-4.0') }
+  let(:vim) { Licensee::License.find('vim') }
   let(:content) { sub_copyright_info(gpl) }
   let(:file) { Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE.txt') }
 
@@ -22,8 +23,8 @@ RSpec.describe Licensee::Matchers::Dice do
 
   it 'sorts licenses by similarity' do
     expect(subject.matches_by_similarity[0]).to eql([gpl, 100.0])
-    expect(subject.matches_by_similarity[1]).to eql([agpl, 95.28301886792453])
-    expect(subject.matches_by_similarity[2]).to eql([lgpl, 39.33253873659118])
+    expect(subject.matches_by_similarity[1]).to eql([agpl, 95.38300104931794])
+    expect(subject.matches_by_similarity[2]).to eql([lgpl, 42.36200256739409])
   end
 
   it 'returns the match confidence' do
@@ -73,6 +74,16 @@ RSpec.describe Licensee::Matchers::Dice do
         expect(subject.match).to be_nil
         expect(subject.matches).to be_empty
         expect(subject.confidence).to be(0)
+      end
+    end
+  end
+
+  context 'Vim long text' do
+    context 'Vim' do
+      let(:content) { vim.content.gsub(/\[project\]/, 'Vim') }
+
+      it 'matches' do
+        expect(content).to be_detected_as(vim)
       end
     end
   end


### PR DESCRIPTION
I found that Github already support Vim license https://api.github.com/licenses/vim 
But none of the three repo listed shows "Vim License"

What I found:
1. Starting from Licensee 9.14. The Vim project will not detect as Vim license. The reason is the commit https://github.com/licensee/licensee/commit/8fe6e80fd9d407fd26e3d8c0b1899fb787f1a372
    It works fine at 9.13.2

    So in this PR I update the parameter of the penalty. I believe the constant `10` is a human decide value. So after some test I use `13` instead. I also add a test case to test the Vim license.

2. The [vim-pathogen](https://github.com/tpope/vim-pathogen) can be detect as Vim license using licensee cli(9.14). Because the length of repos's name `vim-pathogen` is close to `[project]`. But on GitHub it is still not detect as "Vim License". I am not sure why this happens. Maybe GitHub only apply some matchers?