### PR TITLE
rm rubocop from codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,4 @@
 version: "2"
 plugins:
-  rubocop:
-    enabled: true
-    channel: rubocop-0-63
   shellcheck:
     enabled: true


### PR DESCRIPTION
- rubocop is already run in CI
- it is erroring out in https://codeclimate.com/github/benbalter/licensee/builds/55 (I bet it has since #401 since the configured version of rubocop may have been pre-rubocop-performance)
- codecliamte defaults to an old version of rubocop, and it would be a pain to keep in sync