### PR TITLE
Vendor and update tests for choosealicense.com#779: Convert license `using` array to map

### DIFF
--- a/spec/fixtures/detect.json
+++ b/spec/fixtures/detect.json
@@ -8,17 +8,11 @@
         "source": "https://spdx.org/licenses/MIT.html",
         "description": "A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
         "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.",
-        "using": [
-          {
-            "Babel": "https://github.com/babel/babel/blob/master/LICENSE"
-          },
-          {
-            ".NET Core": "https://github.com/dotnet/runtime/blob/master/LICENSE.TXT"
-          },
-          {
-            "Rails": "https://github.com/rails/rails/blob/master/MIT-LICENSE"
-          }
-        ],
+        "using": {
+          "Babel": "https://github.com/babel/babel/blob/master/LICENSE",
+          ".NET Core": "https://github.com/dotnet/runtime/blob/master/LICENSE.TXT",
+          "Rails": "https://github.com/rails/rails/blob/master/MIT-LICENSE"
+        },
         "featured": true,
         "hidden": false,
         "nickname": null,

--- a/spec/licensee/hash_helper_spec.rb
+++ b/spec/licensee/hash_helper_spec.rb
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 
-RSpec.describe Licensee::HashHelper do
-  class HashHelperSpecFixture
-    include Licensee::HashHelper
-    HASH_METHODS = %w[string array rule rules nil_value].freeze
+class HashHelperSpecFixture
+  include Licensee::HashHelper
+  HASH_METHODS = %w[string array rule rules nil_value].freeze
 
-    def string
-      'foo'
-    end
-
-    def array
-      [1, 2, 3]
-    end
-
-    def rule
-      rules.first
-    end
-
-    def rules
-      Licensee::Rule.all
-    end
-
-    def baz
-      'baz'
-    end
-
-    def nil_value
-      nil
-    end
+  def string
+    'foo'
   end
 
+  def array
+    [1, 2, 3]
+  end
+
+  def rule
+    rules.first
+  end
+
+  def rules
+    Licensee::Rule.all
+  end
+
+  def baz
+    'baz'
+  end
+
+  def nil_value
+    nil
+  end
+end
+
+RSpec.describe Licensee::HashHelper do
   let(:fixture) { HashHelperSpecFixture.new }
   let(:hash) { fixture.to_h }
   let(:expected) do

--- a/spec/licensee/license_meta_spec.rb
+++ b/spec/licensee/license_meta_spec.rb
@@ -115,17 +115,11 @@ RSpec.describe Licensee::LicenseMeta do
   context 'to_h' do
     let(:hash) { subject.to_h }
     let(:using) do
-      [
-        {
-          'Babel' => 'https://github.com/babel/babel/blob/master/LICENSE'
-        },
-        {
-          '.NET Core' => 'https://github.com/dotnet/runtime/blob/master/LICENSE.TXT'
-        },
-        {
-          'Rails' => 'https://github.com/rails/rails/blob/master/MIT-LICENSE'
-        }
-      ]
+      {
+        'Babel'     => 'https://github.com/babel/babel/blob/master/LICENSE',
+        '.NET Core' => 'https://github.com/dotnet/runtime/blob/master/LICENSE.TXT',
+        'Rails'     => 'https://github.com/rails/rails/blob/master/MIT-LICENSE'
+      }
     end
     let(:expected) do
       {

--- a/spec/licensee/matchers/matcher_spec.rb
+++ b/spec/licensee/matchers/matcher_spec.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+class MatcherSpecFixture < Licensee::Matchers::Matcher
+  def confidence
+    0
+  end
+end
+
 RSpec.describe Licensee::Matchers::Matcher do
   subject { described_class.new(file) }
 
@@ -16,12 +22,6 @@ RSpec.describe Licensee::Matchers::Matcher do
   end
 
   context 'to_h' do
-    class MatcherSpecFixture < Licensee::Matchers::Matcher
-      def confidence
-        0
-      end
-    end
-
     subject { MatcherSpecFixture.new(file) }
 
     let(:hash) { subject.to_h }

--- a/vendor/choosealicense.com/_licenses/0bsd.txt
+++ b/vendor/choosealicense.com/_licenses/0bsd.txt
@@ -7,9 +7,9 @@ description: The BSD Zero Clause license goes further than the BSD 2-Clause lice
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.  Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. You may take the additional step of removing the copyright notice.
 
 using:
-  - PickMeUp: https://github.com/nazar-pc/PickMeUp/blob/master/copying.md
-  - smoltcp: https://github.com/m-labs/smoltcp/blob/master/LICENSE-0BSD.txt
-  - Toybox: https://github.com/landley/toybox/blob/master/LICENSE
+  PickMeUp: https://github.com/nazar-pc/PickMeUp/blob/master/copying.md
+  smoltcp: https://github.com/m-labs/smoltcp/blob/master/LICENSE-0BSD.txt
+  Toybox: https://github.com/landley/toybox/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/apache-2.0.txt
+++ b/vendor/choosealicense.com/_licenses/apache-2.0.txt
@@ -12,9 +12,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice in the appendix at the very end of the license text.
 
 using:
-  - Kubernetes: https://github.com/kubernetes/kubernetes/blob/master/LICENSE
-  - PDF.js: https://github.com/mozilla/pdf.js/blob/master/LICENSE
-  - Swift: https://github.com/apple/swift/blob/master/LICENSE.txt
+  Kubernetes: https://github.com/kubernetes/kubernetes/blob/master/LICENSE
+  PDF.js: https://github.com/mozilla/pdf.js/blob/master/LICENSE
+  Swift: https://github.com/apple/swift/blob/master/LICENSE.txt
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/bsd-2-clause.txt
+++ b/vendor/choosealicense.com/_licenses/bsd-2-clause.txt
@@ -9,9 +9,9 @@ description: A permissive license that comes in two variants, the <a href="/lice
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  - go-redis: https://github.com/go-redis/redis/blob/master/LICENSE
-  - Homebrew: https://github.com/Homebrew/brew/blob/master/LICENSE.txt
-  - Pony: https://github.com/ponylang/ponyc/blob/master/LICENSE
+  go-redis: https://github.com/go-redis/redis/blob/master/LICENSE
+  Homebrew: https://github.com/Homebrew/brew/blob/master/LICENSE.txt
+  Pony: https://github.com/ponylang/ponyc/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/bsd-3-clause.txt
+++ b/vendor/choosealicense.com/_licenses/bsd-3-clause.txt
@@ -8,9 +8,9 @@ description: A permissive license similar to the <a href="/licenses/bsd-2-clause
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  - d3: https://github.com/d3/d3/blob/master/LICENSE
-  - LevelDB: https://github.com/google/leveldb/blob/master/LICENSE
-  - Quill: https://github.com/quilljs/quill/blob/develop/LICENSE
+  d3: https://github.com/d3/d3/blob/master/LICENSE
+  LevelDB: https://github.com/google/leveldb/blob/master/LICENSE
+  Quill: https://github.com/quilljs/quill/blob/develop/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/bsd-4-clause.txt
+++ b/vendor/choosealicense.com/_licenses/bsd-4-clause.txt
@@ -7,9 +7,9 @@ description: A permissive license similar to the <a href="/licenses/bsd-3-clause
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 using:
-  - Yosemite Blockchain: https://github.com/YosemiteLabs/yosemite-public-blockchain/blob/master/LICENSE
-  - querybuilder: https://github.com/pwolfgang/querybuilder/blob/master/LICENSE
-  - PMSPAUR-public: https://github.com/ArthurGodet/PMSPAUR-public/blob/master/LICENSE
+  Choco-solver: https://github.com/chocoteam/choco-solver/blob/master/LICENSE
+  PMSPAUR-public: https://github.com/ArthurGodet/PMSPAUR-public/blob/master/LICENSE
+  Switchblade: https://github.com/SwitchbladeBot/switchblade/blob/dev/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/bsl-1.0.txt
+++ b/vendor/choosealicense.com/_licenses/bsl-1.0.txt
@@ -10,9 +10,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: Boost recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the [Boost Software License FAQ](https://www.boost.org/users/license.html#FAQ).
 
 using:
-  - Boost: https://github.com/boostorg/boost/blob/master/LICENSE_1_0.txt
-  - Catch2: https://github.com/catchorg/Catch2/blob/master/LICENSE.txt
-  - DMD: https://github.com/dlang/dmd/blob/master/LICENSE.txt
+  Boost: https://github.com/boostorg/boost/blob/master/LICENSE_1_0.txt
+  Catch2: https://github.com/catchorg/Catch2/blob/master/LICENSE.txt
+  DMD: https://github.com/dlang/dmd/blob/master/LICENSE.txt
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/cc-by-4.0.txt
+++ b/vendor/choosealicense.com/_licenses/cc-by-4.0.txt
@@ -7,9 +7,9 @@ description: Permits almost any use subject to providing credit and license noti
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to solely supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by/4.0/'>canonical URL for the license</a>.
 
 using:
-  - caniuse: https://github.com/Fyrd/caniuse/blob/master/LICENSE
-  - WHATWG HTML standard: https://github.com/whatwg/html/blob/master/LICENSE
-  - Kubernetes documentation: https://github.com/kubernetes/website/blob/master/LICENSE
+  caniuse: https://github.com/Fyrd/caniuse/blob/master/LICENSE
+  WHATWG HTML standard: https://github.com/whatwg/html/blob/master/LICENSE
+  Kubernetes documentation: https://github.com/kubernetes/website/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/cc-by-sa-4.0.txt
+++ b/vendor/choosealicense.com/_licenses/cc-by-sa-4.0.txt
@@ -7,9 +7,9 @@ description: Similar to <a href='/licenses/cc-by-4.0/'>CC-BY-4.0</a> but require
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to solely supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by-sa/4.0/'>canonical URL for the license</a>.
 
 using:
-  - Flight rules for Git: https://github.com/k88hudson/git-flight-rules/blob/master/LICENSE
-  - GitHub-Dark: https://github.com/StylishThemes/GitHub-Dark/blob/master/LICENSE
-  - Material Design Iconic Font: https://github.com/zavoloklom/material-design-iconic-font/blob/master/License.md
+  Flight rules for Git: https://github.com/k88hudson/git-flight-rules/blob/master/LICENSE
+  Material Design Iconic Font: https://github.com/zavoloklom/material-design-iconic-font/blob/master/License.md
+  OWASP MSTG: https://github.com/OWASP/owasp-mstg/blob/master/License.md
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/cc0-1.0.txt
+++ b/vendor/choosealicense.com/_licenses/cc0-1.0.txt
@@ -11,9 +11,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: Creative Commons recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be <a href="https://wiki.creativecommons.org/wiki/CC0_FAQ#May_I_apply_CC0_to_computer_software.3F_If_so.2C_is_there_a_recommended_implementation.3F">found on their website</a>.
 
 using:
-  - Awesome: https://github.com/sindresorhus/awesome/blob/master/license
-  - Shields.io: https://github.com/badges/shields/blob/master/LICENSE
-  - psdash: https://github.com/Jahaja/psdash/blob/master/LICENSE
+  Awesome: https://github.com/sindresorhus/awesome/blob/main/license
+  Shields.io: https://github.com/badges/shields/blob/master/LICENSE
+  psdash: https://github.com/Jahaja/psdash/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/cecill-2.1.txt
+++ b/vendor/choosealicense.com/_licenses/cecill-2.1.txt
@@ -7,9 +7,9 @@ description: Strong copyleft license made by three French public research organi
 how: Create a text file (typically named LICENSE or LICENCE) in the root of your source code and copy the text of the license into the file.
 
 using:
-  - BMC-Tools: https://github.com/ANSSI-FR/bmc-tools/blob/master/LICENCE.txt
-  - Taxe foncière: https://github.com/etalab/taxe-fonciere/blob/master/LICENSE
-  - VITAM: https://github.com/ProgrammeVitam/vitam/blob/master_0.15.x/Licence_CeCILL_V2.1-fr.txt
+  BMC-Tools: https://github.com/ANSSI-FR/bmc-tools/blob/master/LICENCE.txt
+  Taxe foncière: https://github.com/etalab/taxe-fonciere/blob/master/LICENSE
+  VITAM: https://github.com/ProgrammeVitam/vitam/blob/master_0.15.x/Licence_CeCILL_V2.1-fr.txt
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/ecl-2.0.txt
+++ b/vendor/choosealicense.com/_licenses/ecl-2.0.txt
@@ -9,9 +9,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Apereo Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice in the appendix at the very end of the license text.
 
 using:
-  - Sakai: https://github.com/sakaiproject/sakai/blob/master/LICENSE
-  - OAE: https://github.com/oaeproject/Hilary/blob/master/LICENSE
-  - Opencast: https://github.com/opencast/opencast/blob/develop/LICENSE
+  Sakai: https://github.com/sakaiproject/sakai/blob/master/LICENSE
+  OAE: https://github.com/oaeproject/Hilary/blob/master/LICENSE
+  Opencast: https://github.com/opencast/opencast/blob/develop/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/epl-1.0.txt
+++ b/vendor/choosealicense.com/_licenses/epl-1.0.txt
@@ -7,9 +7,9 @@ description: This commercially-friendly copyleft license provides the ability to
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 using:
-  - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
-  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
-  - Quil: https://github.com/quil/quil/blob/master/LICENSE
+  Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
+  JUnit: https://github.com/junit-team/junit4/blob/main/LICENSE-junit.txt
+  Quil: https://github.com/quil/quil/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/epl-2.0.txt
+++ b/vendor/choosealicense.com/_licenses/epl-2.0.txt
@@ -9,9 +9,9 @@ description: This commercially-friendly copyleft license provides the ability to
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 using:
-  - Eclipse SmartHome: https://github.com/eclipse/smarthome/blob/master/LICENSE
-  - openHAB: https://github.com/openhab/openhab-distro/blob/master/LICENSE
-  - SUMO: https://github.com/eclipse/sumo/blob/master/LICENSE
+  Eclipse SmartHome: https://github.com/eclipse/smarthome/blob/master/LICENSE
+  openHAB: https://github.com/openhab/openhab-distro/blob/master/LICENSE
+  SUMO: https://github.com/eclipse/sumo/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/eupl-1.2.txt
+++ b/vendor/choosealicense.com/_licenses/eupl-1.2.txt
@@ -7,9 +7,9 @@ description: The European Union Public Licence (EUPL) is a copyleft free/open so
 how: Indicate “Licensed under the EUPL” following the copyright notice of your source code, for example in a README file or directly in a source code file as a comment.
 
 using:
-  - AethysRotation: https://github.com/SimCMinMax/AethysRotation/blob/master/LICENSE
-  - WildDuck: https://github.com/nodemailer/wildduck/blob/master/LICENSE
-  - ZoneMTA: https://github.com/zone-eu/zone-mta/blob/master/LICENSE
+  AethysRotation: https://github.com/SimCMinMax/AethysRotation/blob/master/LICENSE
+  WildDuck: https://github.com/nodemailer/wildduck/blob/master/LICENSE
+  ZoneMTA: https://github.com/zone-eu/zone-mta/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/gpl-2.0.txt
+++ b/vendor/choosealicense.com/_licenses/gpl-2.0.txt
@@ -12,9 +12,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 using:
-  - AliSQL: https://github.com/alibaba/AliSQL/blob/master/COPYING
-  - Discourse: https://github.com/discourse/discourse/blob/master/LICENSE.txt
-  - Joomla!: https://github.com/joomla/joomla-cms/blob/staging/LICENSE.txt
+  AliSQL: https://github.com/alibaba/AliSQL/blob/master/COPYING
+  Discourse: https://github.com/discourse/discourse/blob/master/LICENSE.txt
+  Joomla!: https://github.com/joomla/joomla-cms/blob/staging/LICENSE.txt
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/gpl-3.0.txt
+++ b/vendor/choosealicense.com/_licenses/gpl-3.0.txt
@@ -13,9 +13,9 @@ how: Create a text file (typically named COPYING, as per GNU conventions) in the
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 using:
-  - Ansible: https://github.com/ansible/ansible/blob/devel/COPYING
-  - Bash: https://git.savannah.gnu.org/cgit/bash.git/tree/COPYING
-  - GIMP: https://git.gnome.org/browse/gimp/tree/COPYING
+  Ansible: https://github.com/ansible/ansible/blob/devel/COPYING
+  Bash: https://git.savannah.gnu.org/cgit/bash.git/tree/COPYING
+  GIMP: https://git.gnome.org/browse/gimp/tree/COPYING
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/isc.txt
+++ b/vendor/choosealicense.com/_licenses/isc.txt
@@ -7,9 +7,9 @@ description: A permissive license lets people do anything with your code with pr
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  - Starship: https://github.com/starship/starship/blob/master/LICENSE
-  - Node.js semver: https://github.com/npm/node-semver/blob/master/LICENSE
-  - OpenStreetMap iD: https://github.com/openstreetmap/iD/blob/develop/LICENSE.md
+  Starship: https://github.com/starship/starship/blob/master/LICENSE
+  Node.js semver: https://github.com/npm/node-semver/blob/master/LICENSE
+  OpenStreetMap iD: https://github.com/openstreetmap/iD/blob/develop/LICENSE.md
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/mit.txt
+++ b/vendor/choosealicense.com/_licenses/mit.txt
@@ -9,9 +9,9 @@ description: A short and simple permissive license with conditions only requirin
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  - Babel: https://github.com/babel/babel/blob/master/LICENSE
-  - .NET Core: https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
-  - Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
+  Babel: https://github.com/babel/babel/blob/master/LICENSE
+  .NET Core: https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
+  Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/mpl-2.0.txt
+++ b/vendor/choosealicense.com/_licenses/mpl-2.0.txt
@@ -11,9 +11,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Mozilla Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license (Exhibit A).
 
 using:
-  - Servo: https://github.com/servo/servo/blob/master/LICENSE
-  - Syncthing: https://github.com/syncthing/syncthing/blob/master/LICENSE
-  - TimelineJS3: https://github.com/NUKnightLab/TimelineJS3/blob/master/LICENSE
+  Servo: https://github.com/servo/servo/blob/master/LICENSE
+  Syncthing: https://github.com/syncthing/syncthing/blob/main/LICENSE
+  TimelineJS3: https://github.com/NUKnightLab/TimelineJS3/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/ncsa.txt
+++ b/vendor/choosealicense.com/_licenses/ncsa.txt
@@ -8,9 +8,9 @@ description: The University of Illinois/NCSA Open Source License, or UIUC licens
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 using:
- - LLDB: https://github.com/llvm-mirror/lldb/blob/master/LICENSE.TXT
- - ROCR-Runtime: https://github.com/RadeonOpenCompute/ROCR-Runtime/blob/master/LICENSE.txt
- - RLTK: https://github.com/chriswailes/RLTK/blob/master/LICENSE
+  ROCR-Runtime: https://github.com/RadeonOpenCompute/ROCR-Runtime/blob/master/LICENSE.txt
+  RLTK: https://github.com/chriswailes/RLTK/blob/master/LICENSE
+  ToaruOS: https://github.com/klange/toaruos/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/odbl-1.0.txt
+++ b/vendor/choosealicense.com/_licenses/odbl-1.0.txt
@@ -8,9 +8,9 @@ description: The Open Database License (ODbL) is a license agreement intended to
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 using:
-  - World Countries: https://github.com/mledoze/countries/blob/master/LICENSE
-  - OpenFlights: https://github.com/jpatokal/openflights/blob/master/data/LICENSE
-  - Public Zone Database: https://github.com/zonedb/zonedb/blob/master/LICENSE.md
+  World Countries: https://github.com/mledoze/countries/blob/master/LICENSE
+  OpenFlights: https://github.com/jpatokal/openflights/blob/master/data/LICENSE
+  Public Zone Database: https://github.com/zonedb/zonedb/blob/master/LICENSE.md
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/ofl-1.1.txt
+++ b/vendor/choosealicense.com/_licenses/ofl-1.1.txt
@@ -10,9 +10,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: This license doesn't require source provision, but recommends it. All files derived from OFL files must remain licensed under the OFL.
 
 using:
-  - FiraCode: https://github.com/tonsky/FiraCode/blob/master/LICENSE
-  - Noto fonts: https://github.com/googlefonts/noto-fonts/blob/master/LICENSE
-  - Fantasque Sans Mono: https://github.com/belluzj/fantasque-sans/blob/master/LICENSE.txt
+  FiraCode: https://github.com/tonsky/FiraCode/blob/master/LICENSE
+  Noto fonts: https://github.com/googlefonts/noto-fonts/blob/master/LICENSE
+  Fantasque Sans Mono: https://github.com/belluzj/fantasque-sans/blob/master/LICENSE.txt
 
 permissions:
   - private-use

--- a/vendor/choosealicense.com/_licenses/osl-3.0.txt
+++ b/vendor/choosealicense.com/_licenses/osl-3.0.txt
@@ -9,9 +9,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: OSL 3.0's author has <a href="https://rosenlaw.com/OSL3.0-explained.htm">provided an explanation</a> behind the creation of the license.
 
 using:
-  - appserver.io: https://github.com/appserver-io/appserver/blob/master/LICENSE.txt
-  - JsonMapper: https://github.com/cweiske/jsonmapper/blob/master/LICENSE
-  - Restyaboard: https://github.com/RestyaPlatform/board/blob/master/LICENSE.txt
+  appserver.io: https://github.com/appserver-io/appserver/blob/master/LICENSE.txt
+  JsonMapper: https://github.com/cweiske/jsonmapper/blob/master/LICENSE
+  Restyaboard: https://github.com/RestyaPlatform/board/blob/master/LICENSE.txt
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/postgresql.txt
+++ b/vendor/choosealicense.com/_licenses/postgresql.txt
@@ -7,9 +7,9 @@ description: A very short, BSD-style license, used specifically for PostgreSQL.
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  - pgBadger: https://github.com/darold/pgbadger/blob/master/LICENSE
-  - pgAdmin: https://github.com/postgres/pgadmin4/blob/master/LICENSE
-  - .NET Access to PostgreSQL: https://github.com/npgsql/npgsql/blob/dev/LICENSE
+  pgBadger: https://github.com/darold/pgbadger/blob/master/LICENSE
+  pgAdmin: https://github.com/postgres/pgadmin4/blob/master/LICENSE
+  .NET Access to PostgreSQL: https://github.com/npgsql/npgsql/blob/main/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/unlicense.txt
+++ b/vendor/choosealicense.com/_licenses/unlicense.txt
@@ -8,9 +8,9 @@ description: A license with no conditions whatsoever which dedicates works to th
 how: Create a text file (typically named UNLICENSE or UNLICENSE.txt) in the root of your source code and copy the text of the license disclaimer into the file.
 
 using:
-  - youtube-dl: https://github.com/rg3/youtube-dl/blob/master/LICENSE
-  - kakoune: https://github.com/mawww/kakoune/blob/master/UNLICENSE
-  - RDF.rb: https://github.com/ruby-rdf/rdf/blob/master/UNLICENSE
+  youtube-dl: https://github.com/rg3/youtube-dl/blob/master/LICENSE
+  kakoune: https://github.com/mawww/kakoune/blob/master/UNLICENSE
+  RDF.rb: https://github.com/ruby-rdf/rdf/blob/master/UNLICENSE
 
 permissions:
   - private-use

--- a/vendor/choosealicense.com/_licenses/upl-1.0.txt
+++ b/vendor/choosealicense.com/_licenses/upl-1.0.txt
@@ -9,9 +9,9 @@ how: Insert the license or a link to it along with a copyright notice into your 
 note: It is recommended to add a link to the license and copyright notice at the top of each source file, example text can be found at https://oss.oracle.com/licenses/upl/.
 
 using:
-  - Oracle Product Boxes for Vagrant: https://github.com/oracle/vagrant-boxes/blob/master/LICENSE
-  - Oracle Product Images for Docker: https://github.com/oracle/docker-images/blob/master/LICENSE
-  - Skater: https://github.com/oracle/Skater/blob/master/LICENSE
+  Oracle Product Images for Docker: https://github.com/oracle/docker-images/blob/master/LICENSE
+  Skater: https://github.com/oracle/Skater/blob/master/LICENSE
+  Soufflé: https://github.com/souffle-lang/souffle/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/vim.txt
+++ b/vendor/choosealicense.com/_licenses/vim.txt
@@ -7,9 +7,9 @@ description: There are no restrictions on using or distributing an unmodified co
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [project] with the project name.
 
 using:
-  - Vim: https://github.com/vim/vim/blob/master/LICENSE
-  - Pathogen: https://github.com/tpope/vim-pathogen/blob/master/LICENSE
-  - vim-license-gen: https://github.com/othree/vim-license/blob/master/LICENSE
+  Vim: https://github.com/vim/vim/blob/master/LICENSE
+  Pathogen: https://github.com/tpope/vim-pathogen/blob/master/LICENSE
+  vim-license-gen: https://github.com/othree/vim-license/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/vendor/choosealicense.com/_licenses/zlib.txt
+++ b/vendor/choosealicense.com/_licenses/zlib.txt
@@ -7,9 +7,9 @@ description: A short permissive license, compatible with GPL. Requires altered s
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  - GLFW: https://github.com/glfw/glfw/blob/master/LICENSE.md
-  - Portainer: https://github.com/portainer/portainer/blob/develop/LICENSE
-  - TinyXML-2: https://github.com/leethomason/tinyxml2/blob/master/LICENSE.txt
+  GLFW: https://github.com/glfw/glfw/blob/master/LICENSE.md
+  Portainer: https://github.com/portainer/portainer/blob/develop/LICENSE
+  TinyXML-2: https://github.com/leethomason/tinyxml2/blob/master/LICENSE.txt
 
 permissions:
   - commercial-use


### PR DESCRIPTION
See https://github.com/github/choosealicense.com/issues/758 (the `using` metadata has a needless layer) and https://github.com/github/choosealicense.com/pull/779

2f9b0ed has all of the relevant changes, b633555 is just to satisfy rubocop, picked from #461 

Trialing here before merging there in case it'd cause problems for licensee.