### PR TITLE
Relax three test expectations to compare for equality instead of identity.

### DIFF
--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Licensee::ContentHelper do
 
   it 'knows the similarity' do
     expect(mit.similarity(subject)).to be_within(1).of(4)
-    expect(mit.similarity(mit)).to be(100.0)
+    expect(mit.similarity(mit)).to eql(100.0)
   end
 
   it 'calculates the hash' do

--- a/spec/licensee/matchers/dice_matcher_spec.rb
+++ b/spec/licensee/matchers/dice_matcher_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Licensee::Matchers::Dice do
   end
 
   it 'returns the match confidence' do
-    expect(subject.confidence).to be(100.0)
+    expect(subject.confidence).to eql(100.0)
   end
 
   context 'without a match' do

--- a/spec/licensee_spec.rb
+++ b/spec/licensee_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Licensee do
     end
 
     it 'exposes the inverse of the confidence threshold' do
-      expect(described_class.inverse_confidence_threshold).to be(0.02)
+      expect(described_class.inverse_confidence_threshold).to eql(0.02)
     end
 
     context 'user overridden' do


### PR DESCRIPTION
For some reason that I didn't investigate in depth, these tests fail when run on Ubuntu on armhf (all other supported architectures are fine).
There may be other places in the tests where the expectations could be updated to use the equality operator instead of identity, but this minimal patch appears to be enough to make the tests happy on armhf.