### PR TITLE
Remove unused `let` from rspec

### DIFF
--- a/spec/vendored_license_spec.rb
+++ b/spec/vendored_license_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'vendored licenses' do
   let(:license_file) do
     Licensee::ProjectFiles::LicenseFile.new(content, filename)
   end
-  let(:detected_license) { license_file&.license }
-  let(:wtfpl) { Licensee::License.find('wtfpl') }
 
   Licensee.licenses(hidden: true).each do |license|
     next if license.pseudo_license?


### PR DESCRIPTION
The reports are not changed from `2462 examples, 0 failures`.
And I run again to make sure with following code, it reports same.

```ruby
  let(:detected_license) { raise Exception; license_file&.license }
  let(:wtfpl) { raise Exception; Licensee::License.find('wtfpl') }
```

Can we remove them? 🤔