### PR TITLE
Remove spurious non-captured 'portions ' from copyright regex

### DIFF
--- a/lib/licensee/matchers/copyright.rb
+++ b/lib/licensee/matchers/copyright.rb
@@ -6,7 +6,7 @@ module Licensee
       attr_reader :file
 
       COPYRIGHT_SYMBOLS = Regexp.union([/copyright/i, /\(c\)/i, "\u00A9", "\xC2\xA9"])
-      REGEX = /#{ContentHelper::START_REGEX}(?:portions )?([_*\-\s]*#{COPYRIGHT_SYMBOLS}.*$)+$/i.freeze
+      REGEX = /#{ContentHelper::START_REGEX}([_*\-\s]*#{COPYRIGHT_SYMBOLS}.*$)+$/i.freeze
       def match
         # NOTE: must use content, and not content_normalized here
         Licensee::License.find('no-license') if /#{REGEX}+\z/io.match?(file.content.strip)


### PR DESCRIPTION
Added at https://github.com/licensee/licensee/commit/1a05d304b5f5e26bc43c96765b4d2fce79bc02bc#diff-e234bd0a01fc1a5388ce568c04436272a1573ab603a4ad5ce32b20a2a8f51155R8 though I suspect spurious, as there's no reason 'portions  ' would appear in a copyright line, nor to treat it specially.

I'd started looking at https://github.com/licensee/licensee/issues/493#issuecomment-841709935 and will revisit, just getting this commit pushed before I forget what it was about.