### PR TITLE
Use eq rather than be in tests for floating point numbers

### DIFF
--- a/spec/licensee/content_helper_spec.rb
+++ b/spec/licensee/content_helper_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Licensee::ContentHelper do
 
   it 'knows the similarity' do
     expect(mit.similarity(subject)).to be_within(1).of(4)
-    expect(mit.similarity(mit)).to be(100.0)
+    expect(mit.similarity(mit)).to eq(100.0)
   end
 
   it 'calculates simple delta for similarity' do

--- a/spec/licensee/matchers/dice_matcher_spec.rb
+++ b/spec/licensee/matchers/dice_matcher_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Licensee::Matchers::Dice do
   end
 
   it 'returns the match confidence' do
-    expect(subject.confidence).to be(100.0)
+    expect(subject.confidence).to eq(100.0)
   end
 
   context 'without a match' do

--- a/spec/licensee_spec.rb
+++ b/spec/licensee_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Licensee do
     end
 
     it 'exposes the inverse of the confidence threshold' do
-      expect(described_class.inverse_confidence_threshold).to be(0.02)
+      expect(described_class.inverse_confidence_threshold).to eq(0.02)
     end
 
     context 'user overridden' do


### PR DESCRIPTION
So as to not break tests on i386, and general robustness.

Fixes #503