### PR TITLE
Add Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,21 @@
+name: Docker
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build docker images
+        run: docker build . --tag licensee
+
+      - name: Smoke test
+        run: docker run licensee

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:3.0
+
+WORKDIR /usr/src/app
+RUN git init
+
+RUN apt-get update && apt-get install -y cmake 
+
+COPY Gemfile licensee.gemspec ./
+COPY lib/licensee/version.rb ./lib/licensee/version.rb
+RUN bundle install
+
+COPY bin ./bin
+COPY lib ./lib
+COPY vendor ./vendor
+
+ENTRYPOINT ["bundle", "exec", "./bin/licensee"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,11 +39,15 @@ On Windows, the last line needs to include the Ruby interpreter:
 
     bundle exec ruby bin\licensee
 
-In a Docker Debian Stretch container, minimum dependencies are:
+## Docker
 
-```
-apt-get install -y ruby bundler cmake pkg-config git libssl-dev
-```
+Licensee also comes with a Dockerfile if you prefer to run Licensee within a Docker container:
+
+1. `git clone https://github.com/licensee/licensee && cd licensee`
+2. `docker build . --tag licensee`
+3. `docker run licensee [COMMAND]` (see [command line usage](./command-line-usage.md))
+
+*Example (detecting the license of `rails/rails` on GitHub):* `docker run licensee detect rails/rails --remote`
 
 ## Documentation
 


### PR DESCRIPTION
I saw https://github.com/licensee/licensee/issues/526, and thought it would be easier to maintain a Dockerfile (and potentially down the line, a Docker image) than try to support Ruby environments on different platforms for users unfamiliar with Ruby.

This addition shouldn't affect day-to-day development, but allows users to run Licensee with the following:

1. `git clone https://github.com/licensee/licensee && cd licensee`
2. `docker build . --tag licensee`
3. `docker run licensee [COMMAND]`

It could also be used to facilitate local development, if people would prefer to develop within the docker container, rather than not their system directly.

I've also added a tiny CI job to build the docker container and verify it works to reduce maintenance and prevent regressions down the line.

-----
[View rendered docs/README.md](https://github.com/licensee/licensee/blob/docker/docs/README.md)