### PR TITLE
Reset inverse confidence threshold when user override of confidence threshold is set

### DIFF
--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -47,7 +47,7 @@ module Licensee
     def confidence_threshold
       @confidence_threshold ||= CONFIDENCE_THRESHOLD
     end
-    
+
     def confidence_threshold=(value)
       @confidence_threshold = value
       @inverse_confidence_threshold = nil

--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -24,8 +24,6 @@ module Licensee
   DOMAIN = 'http://choosealicense.com'
 
   class << self
-    attr_writer :confidence_threshold
-
     # Returns an array of Licensee::License instances
     def licenses(options = {})
       Licensee::License.all(options)
@@ -48,6 +46,11 @@ module Licensee
 
     def confidence_threshold
       @confidence_threshold ||= CONFIDENCE_THRESHOLD
+    end
+    
+    def confidence_threshold=(value)
+      @confidence_threshold = value
+      @inverse_confidence_threshold = nil
     end
 
     # Inverse of the confidence threshold, represented as a float

--- a/spec/licensee_spec.rb
+++ b/spec/licensee_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe Licensee do
       it 'lets the user override the confidence threshold' do
         expect(described_class.confidence_threshold).to be(50)
       end
+      
+      it 'resets inverse confidence threshold when confidence threshold changes' do
+        expect(described_class.inverse_confidence_threshold).to be(0.5)
+        described_class.confidence_threshold = Licensee.confidence_threshold
+        expect(described_class.inverse_confidence_threshold).to be(0.02)
+      end
     end
   end
 end

--- a/spec/licensee_spec.rb
+++ b/spec/licensee_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Licensee do
       it 'lets the user override the confidence threshold' do
         expect(described_class.confidence_threshold).to be(50)
       end
-      
+
       it 'resets inverse confidence threshold when confidence threshold changes' do
         expect(described_class.inverse_confidence_threshold).to be(0.5)
         described_class.confidence_threshold = Licensee::CONFIDENCE_THRESHOLD

--- a/spec/licensee_spec.rb
+++ b/spec/licensee_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Licensee do
       
       it 'resets inverse confidence threshold when confidence threshold changes' do
         expect(described_class.inverse_confidence_threshold).to be(0.5)
-        described_class.confidence_threshold = Licensee.confidence_threshold
+        described_class.confidence_threshold = Licensee::CONFIDENCE_THRESHOLD
         expect(described_class.inverse_confidence_threshold).to be(0.02)
       end
     end


### PR DESCRIPTION
This relates to [changes in the licensed gem](https://github.com/github/licensed/pull/455) that allows users to customize Licensee's confidence threshold when evaluating OSS dependencies in an application.  I noticed that when changing the confidence threshold the inverse was not updating to match the change.  I made a small change here to reset the memoized value to nil when a user customizes the threshold value.