### PR TITLE
docs: update note about multiple matches

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,6 +26,8 @@ license.meta["permissions"]
 => ["commercial-use","modifications","distribution","private-use"]
 ```
 
+Consider handling multiple conflicting license matches. See [what we look at](what-we-look-at.md).
+
 ### Providing an access token
 
 If you wish to scan private GitHub repositories, or are hitting API rate limits, you can configure the embedded [Octokit](https://github.com/octokit/octokit.rb)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,7 +30,7 @@ license.meta["permissions"]
 Consider handling multiple conflicting license matches. See [what we look at](what-we-look-at.md).
 
 ```ruby
-project = Licensee.project("/path/to/a/project")
+project = Licensee.project "/path/to/a/project"
 
 project.licenses
 => # an array of all matching licenses

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,9 +24,17 @@ license.meta["description"]
 
 license.meta["permissions"]
 => ["commercial-use","modifications","distribution","private-use"]
+
 ```
 
 Consider handling multiple conflicting license matches. See [what we look at](what-we-look-at.md).
+
+```ruby
+project = Licensee.project("/path/to/a/project")
+
+project.licenses
+=> # an array of all matching licenses
+```
 
 ### Providing an access token
 

--- a/docs/what-we-look-at.md
+++ b/docs/what-we-look-at.md
@@ -14,7 +14,7 @@ Licensee uses [a series of regular expressions](https://github.com/benbalter/lic
 * `COPYRIGHT`
 * `UNLICENSE`
 
-If the project has multiple license files or a file named `license` or similar (as defined by the regular expressions linked above) that doesn't contain a only one well known license (see below) in its standard form, chances are Licensee won't detect the project's license.
+:warning: If the project has multiple license matches (e.g. a package file match, a file named license or similar that matches the regular expressions) that don't only match one well known license (see below), Licensee won't return a license for the project, but all matches are returned in the licenses array.
 
 ### Known licenses
 


### PR DESCRIPTION
I think we should add an example for getting all the license matches, but the current example only returns one license: `license = Licensee.license "/path/to/a/project"`

But I don't know how is the API for getting all the matches, is it just: `licenses = Licensee.licenses "/path/to/a/project"`?

-----
[View rendered docs/usage.md](https://github.com/granodigital/licensee/blob/chore/update-docs/docs/usage.md)
[View rendered docs/what-we-look-at.md](https://github.com/granodigital/licensee/blob/chore/update-docs/docs/what-we-look-at.md)