### PR TITLE
Update fixtures when vendored licenses updated

### DIFF
--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Vendor SPDX
         run: script/vendor-spdx
 
+      - name: Update test fixture
+        run: script/dump-detect-json-fixture
+
+      - name: Update license hashes
+        run: script/hash-licenses
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/spec/fixtures/detect.json
+++ b/spec/fixtures/detect.json
@@ -10,7 +10,7 @@
         "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.",
         "using": {
           "Babel": "https://github.com/babel/babel/blob/master/LICENSE",
-          ".NET Core": "https://github.com/dotnet/runtime/blob/master/LICENSE.TXT",
+          ".NET": "https://github.com/dotnet/runtime/blob/main/LICENSE.TXT",
           "Rails": "https://github.com/rails/rails/blob/master/MIT-LICENSE"
         },
         "featured": true,

--- a/spec/licensee/license_meta_spec.rb
+++ b/spec/licensee/license_meta_spec.rb
@@ -116,9 +116,9 @@ RSpec.describe Licensee::LicenseMeta do
     let(:hash) { subject.to_h }
     let(:using) do
       {
-        'Babel'     => 'https://github.com/babel/babel/blob/master/LICENSE',
-        '.NET Core' => 'https://github.com/dotnet/runtime/blob/master/LICENSE.TXT',
-        'Rails'     => 'https://github.com/rails/rails/blob/master/MIT-LICENSE'
+        'Babel' => 'https://github.com/babel/babel/blob/master/LICENSE',
+        '.NET'  => 'https://github.com/dotnet/runtime/blob/main/LICENSE.TXT',
+        'Rails' => 'https://github.com/rails/rails/blob/master/MIT-LICENSE'
       }
     end
     let(:expected) do


### PR DESCRIPTION
Otherwise tests mail fail.

(They mail still fail, thus update to hardcoded in license_meta_spec this time)