### PR TITLE
Enable Exact matcher to detect OFL with a reserved font name

### DIFF
--- a/lib/licensee/matchers/copyright.rb
+++ b/lib/licensee/matchers/copyright.rb
@@ -6,7 +6,9 @@ module Licensee
       attr_reader :file
 
       COPYRIGHT_SYMBOLS = Regexp.union([/copyright/i, /\(c\)/i, "\u00A9", "\xC2\xA9"])
-      REGEX = /#{ContentHelper::START_REGEX}([_*\-\s]*#{COPYRIGHT_SYMBOLS}.*$)+$/i.freeze
+      MAIN_LINE_REGEX = /[_*\-\s]*#{COPYRIGHT_SYMBOLS}.*$/i.freeze
+      OPTIONAL_LINE_REGEX = /[_*\-\s]*with Reserved Font Name.*$/i.freeze
+      REGEX = /#{ContentHelper::START_REGEX}(#{MAIN_LINE_REGEX}#{OPTIONAL_LINE_REGEX}*)+$/i.freeze
       def match
         # NOTE: must use content, and not content_normalized here
         Licensee::License.find('no-license') if /#{REGEX}+\z/io.match?(file.content.strip)

--- a/spec/licensee/matchers/copyright_matcher_spec.rb
+++ b/spec/licensee/matchers/copyright_matcher_spec.rb
@@ -27,10 +27,11 @@ RSpec.describe Licensee::Matchers::Copyright do
     'UTF-8 Encoded'         => 'Copyright (c) 2010-2014 Simon Hürlimann',
     'Comma-separated date'  => 'Copyright (c) 2003, 2004 Ben Balter',
     'Hyphen-separated date' => 'Copyright (c) 2003-2004 Ben Balter',
-    'ASCII-8BIT encoded'    => "Copyright \xC2\xA92015 Ben Balter`",
+    'ASCII-8BIT encoded'    => "Copyright \xC2\xA92015 Ben Balter`"
+      .dup.force_encoding('ASCII-8BIT'),
     'No year'               => 'Copyright Ben Balter',
-    'Multiline'             => "Copyright Ben Balter\nCopyright Another Entity"
-      .dup.force_encoding('ASCII-8BIT')
+    'Multiline'             => "Copyright Ben Balter\nCopyright Another Entity",
+    'OFL font name'         => "Copyright (c) 2016, Ben Balter,\nwith Reserved Font Name \"Ben's Font\"."
   }.each do |description, notice|
     context "with a #{description} notice" do
       let(:content) { notice }

--- a/spec/licensee/matchers/copyright_matcher_spec.rb
+++ b/spec/licensee/matchers/copyright_matcher_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Licensee::Matchers::Copyright do
     end
   end
 
+  context 'with arbitrary additional notice line' do
+    let(:content) { "(c) Ben Balter\nwith foo bar baz" }
+
+    it "doesn't match" do
+      expect(subject.match).to be_nil
+    end
+  end
+
   context 'with a license with a copyright notice' do
     let(:content) { sub_copyright_info(mit) }
 


### PR DESCRIPTION
This pull request fixes issue #523.

The solution is to expand copyright regex to include the line that mentions a reserved font name, as mentioned on the issue.