### PR TITLE
Remove deprecated --path argument to bundler in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ To use licensee programmatically in your own Ruby project, add `gem 'licensee'` 
 To run licensee directly from source:
 
     gem install bundler
-    bundle install --path vendor/bundle
+    bundle install
     bundle exec bin/licensee
 
 On Windows, the last line needs to include the Ruby interpreter:


### PR DESCRIPTION
Fixes #524

-----
[View rendered docs/README.md](https://github.com/licensee/licensee/blob/bundler-path-readme/docs/README.md)