### PR TITLE
Install dependencies in vendor workflow

### DIFF
--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -16,7 +16,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1
-          bundler-cache: true 
+          bundler-cache: true
+
+      - name: Install depenencies
+        run: bundle install
 
       - name: Vendor Licenses
         run: script/vendor-licenses


### PR DESCRIPTION
Install dependencies to avoid

```
Run script/dump-detect-json-fixture
<internal:/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- licensee (LoadError)
	from <internal:/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from script/dump-detect-json-fixture:5:in `<main>'
Error: Process completed with exit code 1.
```