### PR TITLE
Push image to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,11 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  IMAGE_NAME: licensee/licensee
+
 jobs:
-  build-image:
+  build-and-push:
     runs-on: ubuntu-latest
 
     steps:
@@ -15,7 +18,18 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build docker images
-        run: docker build . --tag licensee
+        run: docker build . --tag $IMAGE_NAME
 
       - name: Smoke test
-        run: docker run licensee
+        run: docker run $IMAGE_NAME
+        
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push the image
+        if: github.event_name != 'pull_request'
+        run: docker push $IMAGE_NAME


### PR DESCRIPTION
Following #527 to push the image to Docker Hub.

This requires registering a username and setting up auth token at https://docs.docker.com/docker-hub/

Make it easier to launch `licensee` without downloading and building the image by hand.