### PR TITLE
avoid annoying warning when used with faraday 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,10 @@
 
 source 'https://rubygems.org'
 
+faraday_version = ENV.fetch('FARADAY_VERSION', '~> 2.0')
+
+gem 'faraday', faraday_version
+
+gem 'faraday-retry' if faraday_version.start_with?('~> 2')
+
 gemspec


### PR DESCRIPTION
Adding conditional to Gemfile will install faraday-retry if faraday 2 without requiring faraday 2 copied approach from octokit itself https://github.com/octokit/octokit.rb/commit/f2a11a9944a2c7c5b9511dc9c54904da01c6dfa7 after reading https://github.com/octokit/octokit.rb/discussions/1486

The warning below otherwise appears once per run when Octokit functionality is used (ie remote, including some tests in CI) if faraday 2 is installed:

> To use retry middleware with Faraday v2.0+, install faraday-retry gem

Alternative would be to require Faraday ~> 2.0 but apparently many applications are still at 1, which presumably is why Octokit doesn't require 2 itself.