### PR TITLE
License name extensions

### DIFF
--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -9,6 +9,10 @@ module Licensee
       PREFERRED_EXT = %w[md markdown txt html].freeze
       PREFERRED_EXT_REGEX = /\.#{Regexp.union(PREFERRED_EXT)}\z/.freeze
 
+      # List of short license names that can be used as extensions
+      LICENSE_NAME_EXT = %w[AGPLv3 GPLv3 LGPLv3 MIT MPLv2].freeze
+      LICENSE_NAME_EXT_REGEX = /\.#{Regexp.union(LICENSE_NAME_EXT)}\z/.freeze
+
       # Regex to match any extension except .spdx or .header
       LICENSE_EXT_REGEX = %r{\.(?!spdx|header)[^./]+\z}i.freeze
 

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -38,6 +38,7 @@ module Licensee
       # Hash of Regex => score with which to score potential license files
       FILENAME_REGEXES = {
         /\A#{LICENSE_REGEX}\z/                                => 1.00,  # LICENSE
+        /\A#{LICENSE_REGEX}#{LICENSE_EXT_REGEX}\z/            => 0.97,  # LICENSE.MIT
         /\A#{LICENSE_REGEX}#{PREFERRED_EXT_REGEX}\z/          => 0.95,  # LICENSE.md
         /\A#{COPYING_REGEX}\z/                                => 0.90,  # COPYING
         /\A#{COPYING_REGEX}#{PREFERRED_EXT_REGEX}\z/          => 0.85,  # COPYING.md


### PR DESCRIPTION
Explicitly match `LICENSE.SHORT_NAME` file naming convention. Examples:

 - `LICENSE.AGPLv3`
 - `LICENSE.MIT`

This change knocks down a bit licensee's confidence in other extensions like `txt` and `md`.

```
expected: 0.95
     got: 0.8

rspec ./spec/licensee/project_files/license_file_spec.rb[1:8:7:1] # Licensee::ProjectFiles::LicenseFile filename scoring a file named license.txt scores the file
rspec ./spec/licensee/project_files/license_file_spec.rb[1:8:5:1] # Licensee::ProjectFiles::LicenseFile filename scoring a file named license.md scores the file
rspec ./spec/licensee/project_files/license_file_spec.rb[1:8:6:1] # Licensee::ProjectFiles::LicenseFile filename scoring a file named LICENSE.md scores the file

```

Is this appropriate? If not, can I get some feedback on how to handle this properly?