### PR TITLE
rm unused lets in cran spec

### DIFF
--- a/spec/licensee/matchers/cran_matcher_spec.rb
+++ b/spec/licensee/matchers/cran_matcher_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe Licensee::Matchers::Cran do
   subject { described_class.new(file) }
 
   let(:mit) { Licensee::License.find('mit') }
-  let(:gpl2) { Licensee::License.find('gpl-2.0') }
-  let(:gpl3) { Licensee::License.find('gpl-3.0') }
   let(:content) { "License: MIT + file LICENSE\nPackage: test" }
   let(:file) { Licensee::ProjectFiles::LicenseFile.new(content, 'DESCRIPTION') }
 


### PR DESCRIPTION
Saw due to silly new https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecindexedlet turns out the offending lets weren't used, so removed!