### PR TITLE
Allow latest Octokit version

### DIFF
--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.executables << 'licensee'
 
   gem.add_dependency('dotenv', '~> 2.0')
-  gem.add_dependency('octokit', '>= 4.20', '< 8.0')
+  gem.add_dependency('octokit', '>= 4.20', '< 9.0')
   gem.add_dependency('reverse_markdown', '>= 1', '< 3')
   gem.add_dependency('rugged', '>= 0.24', '<2.0')
   gem.add_dependency('thor', '>= 0.19', '< 2.0')


### PR DESCRIPTION
Octokit 8 was recently released with no big changes, it should work ok with Licensee.
https://github.com/octokit/octokit.rb/releases/tag/v8.0.0