### PR TITLE
License-path command fix

### DIFF
--- a/lib/licensee/commands/license_path.rb
+++ b/lib/licensee/commands/license_path.rb
@@ -2,15 +2,15 @@
 
 class LicenseeCLI < Thor
   desc 'license-path [PATH]', "Returns the path to the given project's license file"
-  def license_path(_path)
-    if project.license_file
-      if remote?
-        say project.license_file.path
-      else
-        say File.expand_path project.license_file.path
-      end
+  def license_path(path)
+    project = Licensee.project(path)
+
+    exit 1 unless project.license_file
+
+    if remote?
+      say project.license_file.path
     else
-      exit 1
+      say File.expand_path(project.license_file.path, path)
     end
   end
 end

--- a/spec/licensee/commands/license_path_spec.rb
+++ b/spec/licensee/commands/license_path_spec.rb
@@ -2,7 +2,8 @@
 
 RSpec.describe 'license-path command' do
   let(:command) { ['bundle', 'exec', 'bin/licensee', 'license-path'] }
-  let(:arguments) { [project_root] }
+  let(:project_path) { fixture_path('mit_markdown') }
+  let(:arguments) { [project_path] }
   let(:output) do
     Dir.chdir project_root do
       Open3.capture3(*[command, arguments].flatten)
@@ -14,7 +15,7 @@ RSpec.describe 'license-path command' do
   let(:status) { output[2] }
 
   it 'returns the license path' do
-    expect(stdout).to match(File.join(project_root, 'LICENSE.md'))
+    expect(stdout).to match(File.join(project_path, 'LICENSE.md'))
   end
 
   it 'Returns a zero exit code' do


### PR DESCRIPTION
Fixes #667

Steps to validate:
1. run `licensee license-path /path/to/my/repo` that is not current repo
2. validate that output is correct