### PR TITLE
Increase maximum Octokit version

### DIFF
--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.executables << 'licensee'
 
   gem.add_dependency('dotenv', '>= 2', '< 4')
-  gem.add_dependency('octokit', '>= 4.20', '< 9.0')
+  gem.add_dependency('octokit', '>= 4.20', '< 10.0')
   gem.add_dependency('reverse_markdown', '>= 1', '< 3')
   gem.add_dependency('rugged', '>= 0.24', '<2.0')
   gem.add_dependency('thor', '>= 0.19', '< 2.0')


### PR DESCRIPTION
### Reason
Octokit has been recently updated to version 9.0 and the current version of Licensee is not compatible with this version. This pull request increases the maximum version of Octokit to `< 10.0` to allow the use of newer versions of Octokit, where the new GHES Manage Client has been introduced. 
This update is necessary to be able to update `licensee` in `licensed` or order to use the new client in the GHES Management Console.

### Changes
This pull request includes a change to the `licensee.gemspec` file. The dependency version for `octokit` has been updated from `< 9.0` to `< 10.0`. This change allows the use of newer versions of the `octokit` gem.