### PR TITLE
Allow periods in file extensions when they form a part of a version number

### DIFF
--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -9,15 +9,15 @@ module Licensee
       PREFERRED_EXT = %w[md markdown txt html].freeze
       PREFERRED_EXT_REGEX = /\.#{Regexp.union(PREFERRED_EXT)}\z/
 
-      # Regex to match any extension except .spdx or .header
-      LICENSE_EXT_REGEX = %r{\.(?!spdx|header)[^./]+\z}i
+      # Regex to match any extension and periods in version numbers except .spdx or .header
+      LICENSE_EXT_REGEX = %r{\.(?!spdx|header)([^./]|\.\d)+\z}i
 
-      # Regex to match any extension except a few unlikely as license
+      # Regex to match any extension and periods in version numbers except a few unlikely as license
       # texts with complex filenames
-      OTHER_EXT_REGEX = %r{\.(?!xml|go|gemspec)[^./]+\z}i
+      OTHER_EXT_REGEX = %r{\.(?!xml|go|gemspec)([^./]|\.\d)+\z}i
 
       # Regex to match any extension and periods in version numbers
-      ANY_EXT_REGEX = %r{\.([^./]|.\d)+\z}i
+      ANY_EXT_REGEX = %r{\.([^./]|\.\d)+\z}i
 
       # Regex to match, LICENSE, LICENCE, unlicense, etc.
       LICENSE_REGEX = /(un)?licen[sc]e/i

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -16,8 +16,8 @@ module Licensee
       # texts with complex filenames
       OTHER_EXT_REGEX = %r{\.(?!xml|go|gemspec)[^./]+\z}i
 
-      # Regex to match any extension
-      ANY_EXT_REGEX = %r{\.[^./]+\z}i
+      # Regex to match any extension and periods in version numbers
+      ANY_EXT_REGEX = %r{\.([^./]|.\d)+\z}i
 
       # Regex to match, LICENSE, LICENCE, unlicense, etc.
       LICENSE_REGEX = /(un)?licen[sc]e/i

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Licensee::ProjectFiles::LicenseFile do
       'copyRIGHT'           => 0.90,
       'COPYRIGHT.txt'       => 0.85,
       'copying.txt'         => 0.85,
+      'LICENSE.MPL-2.0'     => 0.80,
       'LICENSE.php'         => 0.80,
       'LICENCE.docs'        => 0.80,
       'license.xml'         => 0.80,


### PR DESCRIPTION
Allows `LICENSE.AGPL-3.0-only`, `LICENSE.MPL-2.0`, etc.

Resolves #732 