### PR TITLE
Prioritize files likely to have actual license content

### DIFF
--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -22,8 +22,11 @@ module Licensee
       # Regex to match, LICENSE, LICENCE, unlicense, etc.
       LICENSE_REGEX = /(un)?licen[sc]e/i
 
-      # Regex to match COPYING, COPYRIGHT, etc.
-      COPYING_REGEX = /copy(ing|right)/i
+      # Regex to match COPYING
+      COPYING_REGEX = /copying/i
+
+      # Regex to match COPYRIGHT
+      COPYRIGHT_REGEX = /copyright/i
 
       # Regex to match OFL.
       OFL_REGEX = /ofl/i
@@ -46,8 +49,12 @@ module Licensee
         /\A#{OFL_REGEX}#{PREFERRED_EXT_REGEX}/                => 0.50,  # OFL.md
         /\A#{OFL_REGEX}#{OTHER_EXT_REGEX}/                    => 0.45,  # OFL.textile
         /\A#{OFL_REGEX}\z/                                    => 0.40,  # OFL
-        /\A#{PATENTS_REGEX}\z/                                => 0.35,  # PATENTS
-        /\A#{PATENTS_REGEX}#{OTHER_EXT_REGEX}\z/              => 0.30,  # PATENTS.txt
+        /\A#{COPYRIGHT_REGEX}\z/                              => 0.35,  # COPYRIGHT
+        /\A#{COPYRIGHT_REGEX}#{PREFERRED_EXT_REGEX}\z/        => 0.30,  # COPYRIGHT.txt
+        /\A#{COPYRIGHT_REGEX}#{OTHER_EXT_REGEX}\z/            => 0.25,  # COPYRIGHT.textile
+        /\A#{COPYRIGHT_REGEX}[-_][^.]*#{OTHER_EXT_REGEX}?\z/  => 0.20,  # COPYRIGHT-MIT
+        /\A#{PATENTS_REGEX}\z/                                => 0.15,  # PATENTS
+        /\A#{PATENTS_REGEX}#{OTHER_EXT_REGEX}\z/              => 0.10,  # PATENTS.txt
         //                                                    => 0.00   # Catch all
       }.freeze
 

--- a/spec/licensee/project_files/license_file_spec.rb
+++ b/spec/licensee/project_files/license_file_spec.rb
@@ -65,19 +65,18 @@ RSpec.describe Licensee::ProjectFiles::LicenseFile do
       'LICENSE.md'          => 0.95,
       'license.txt'         => 0.95,
       'COPYING'             => 0.90,
-      'copyRIGHT'           => 0.90,
-      'COPYRIGHT.txt'       => 0.85,
+      'copyRIGHT'           => 0.35,
+      'COPYRIGHT.txt'       => 0.30,
       'copying.txt'         => 0.85,
       'LICENSE.MPL-2.0'     => 0.80,
       'LICENSE.php'         => 0.80,
       'LICENCE.docs'        => 0.80,
       'license.xml'         => 0.80,
       'copying.image'       => 0.75,
-      'COPYRIGHT.go'        => 0.75,
       'LICENSE-MIT'         => 0.70,
       'LICENSE_1_0.txt'     => 0.70,
       'COPYING-GPL'         => 0.65,
-      'COPYRIGHT-BSD'       => 0.65,
+      'COPYRIGHT-BSD'       => 0.20,
       'MIT-LICENSE.txt'     => 0.60,
       'mit-license-foo.md'  => 0.60,
       'OFL.md'              => 0.50,
@@ -149,14 +148,6 @@ RSpec.describe Licensee::ProjectFiles::LicenseFile do
       %w[LICENSE licence unlicense LICENSE-MIT MIT-LICENSE].each do |license|
         it "matches #{license}" do
           expect(described_class::LICENSE_REGEX).to match(license)
-        end
-      end
-    end
-
-    context 'copying regex' do
-      %w[COPYING copyright].each do |copying|
-        it "matches #{copying}" do
-          expect(described_class::COPYING_REGEX).to match(copying)
         end
       end
     end


### PR DESCRIPTION
Lower "filename scoring" of files like `copyright` so that most relevant files are reported on first.