### PR TITLE
Add ruby 3.4 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.0, 3.1, 3.2, 3.3]
+        ruby: [3.0, 3.1, 3.2, 3.3, 3.4]
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Unlike some prior years (#616 #694) I don't see a specific reason (My naive approach: are there any new suggestions from rubocop with `TargetRubyVersion: 3.1`? No.) to drop 3.0 besides that it is EOL, so this only adds 3.4 to the test matrix.

Feel free to shout if there's a better approach.