### PR TITLE
Extend fixtures to test for multiple licenses

### DIFF
--- a/spec/fixture_spec.rb
+++ b/spec/fixture_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe 'fixture test' do
       let(:other) { Licensee::License.find('other') }
       let(:none) { Licensee::License.find('none') }
       let(:expectations) { fixture_licenses[fixture] || {} }
+      let(:expected_key) {
+        if expectations['key']
+          Licensee::License.find(expectations['key'])
+        else
+          none
+        end
+      }
       let(:license_file) { subject.license_file }
       let(:matcher) { license_file&.matcher }
 
@@ -22,14 +29,20 @@ RSpec.describe 'fixture test' do
         expect(fixture_licenses).to have_key(fixture), msg
       end
 
-      it 'detects the license' do
-        expected = if expectations['key']
-                     Licensee::License.find(expectations['key'])
+      it 'detects the license key' do
+        expect(subject.license).to eql(expected_key)
+      end
+
+      it 'detects multiple license' do
+        expected = if expectations['licenses']
+                     expectations['licenses'].map do |license|
+                       Licensee::License.find(license)
+                     end
                    else
-                     none
+                     [expected_key]
                    end
 
-        expect(subject.license).to eql(expected)
+        expect(subject.licenses).to eql(expected)
       end
 
       it 'returns the expected hash' do

--- a/spec/fixtures/fixtures.yml
+++ b/spec/fixtures/fixtures.yml
@@ -44,6 +44,7 @@ bsd-plus-patents:
   key: other
   matcher:
   hash:
+  licenses: [bsd-3-clause, other]
 bsl:
   key: bsl-1.0
   matcher: exact
@@ -104,6 +105,7 @@ description-license:
   key: other
   matcher:
   hash: ab0fb718684bbc67c7dfc2e9ab2175dab4fcb819
+  licenses: [other, mit]
 epl-1.0_markdown:
   key: epl-1.0
   matcher: dice
@@ -120,6 +122,7 @@ gemspec:
   key:
   matcher:
   hash:
+  licenses: []
 gfdl-1.3_markdown:
   key: gfdl-1.3
   matcher: dice
@@ -148,6 +151,7 @@ lgpl:
   key: lgpl-3.0
   matcher: exact
   hash: 2f434698bab479f8f6c5043f2796767287f40495
+  licenses: [lgpl-3.0, gpl-3.0]
 lgpl-2.1_markdown:
   key: lgpl-2.1
   matcher: dice
@@ -160,6 +164,7 @@ license-folder:
   key:
   matcher:
   hash:
+  licenses: []
 license-in-parent-folder:
   key: mit
   matcher: exact
@@ -180,6 +185,7 @@ mit-with-copyright:
   key: mit
   matcher:
   hash:
+  licenses: [mit, no-license]
 mit_markdown:
   key: mit
   matcher: exact
@@ -200,6 +206,7 @@ multiple-license-files:
   key: other
   matcher:
   hash:
+  licenses: [mpl-2.0, mit]
 pixar-modified-apache:
   key: other
   matcher:
@@ -228,6 +235,7 @@ webmock:
   key:
   matcher:
   hash:
+  licenses: []
 wrk-modified-apache:
   key: other
   matcher:


### PR DESCRIPTION
This factors out testing for multiple licenses in fixtures from #820 to make sure this makes sense before trying to roll out support for `LICENSES/` directories.