### PR TITLE
avoid rubocop plugins migration warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
-require:
+plugins:
   - rubocop-performance
   - rubocop-rspec
 


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/plugin_migration_guide.html