### PR TITLE
Add Ruby 4.0 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.0, 3.1, 3.2, 3.3, 3.4]
+        ruby: [3.0, 3.1, 3.2, 3.3, 3.4, 4.0]
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
This may not work until 4.0 is released, might depend on how setup-ruby resolves (does it use previews not expressly stated)?