### PR TITLE
drop support for eol ruby versions 3.0 and 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.0, 3.1, 3.2, 3.3, 3.4, 4.0]
+        ruby: [3.2, 3.3, 3.4, 4.0]
 
     steps:
       - name: Harden Runner

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   NewCops: enable
   Exclude:
     - tmp/**/*

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
 require 'digest'
 
 module Licensee

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('simplecov', '~> 0.16')
   gem.add_development_dependency('webmock', '~> 3.1')
 
-  gem.required_ruby_version = '>= 3.0'
+  gem.required_ruby_version = '>= 3.2'
 
   # ensure the gem is built out of versioned files
   gem.files = Dir[


### PR DESCRIPTION
Unlike prior year (#804) rubocop does have one new suggestion with EOL ruby versions dropped, included.