### PR TITLE
Fix rubocop Style/Documentation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,7 +32,3 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Max: 6
 
-# Offense count: 36
-# Configuration parameters: AllowedConstants.
-Style/Documentation:
-  Enabled: false

--- a/bin/licensee
+++ b/bin/licensee
@@ -7,6 +7,7 @@ require 'json'
 
 require_relative '../lib/licensee'
 
+# Thor CLI entrypoint for the `licensee` command.
 class LicenseeCLI < Thor
   package_name 'Licensee'
   class_option :remote, type: :boolean, desc: 'Assume PATH is a GitHub owner/repo path'

--- a/lib/licensee.rb
+++ b/lib/licensee.rb
@@ -5,6 +5,7 @@ require 'forwardable'
 require 'pathname'
 require 'yaml'
 
+# Main namespace and public entrypoints for the Licensee gem.
 module Licensee
   autoload :ContentHelper, 'licensee/content_helper'
   autoload :HashHelper, 'licensee/hash_helper'

--- a/lib/licensee/commands/detect.rb
+++ b/lib/licensee/commands/detect.rb
@@ -124,7 +124,7 @@ module Licensee
   end
 end
 
-# `licensee detect` command implementation (Thor).
+# Implementation of the `licensee detect` command.
 class LicenseeCLI < Thor
   include Licensee::Commands::DetectCLIHelpers
 

--- a/lib/licensee/commands/detect.rb
+++ b/lib/licensee/commands/detect.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Commands
+    # Helper methods for formatting `licensee detect` output.
     module DetectCLIHelpers
       # Methods to call when displaying information about ProjectFiles
       MATCHED_FILE_METHODS = %i[
@@ -123,6 +124,7 @@ module Licensee
   end
 end
 
+# `licensee detect` command implementation (Thor).
 class LicenseeCLI < Thor
   include Licensee::Commands::DetectCLIHelpers
 

--- a/lib/licensee/commands/diff.rb
+++ b/lib/licensee/commands/diff.rb
@@ -2,6 +2,7 @@
 
 require 'tmpdir'
 
+# `licensee diff` command implementation (Thor).
 class LicenseeCLI < Thor
   desc 'diff [PATH]', 'Compare the given license text to a known license'
   option :license, type: :string, desc: 'The SPDX ID or key of the license to compare'

--- a/lib/licensee/commands/diff.rb
+++ b/lib/licensee/commands/diff.rb
@@ -2,7 +2,7 @@
 
 require 'tmpdir'
 
-# `licensee diff` command implementation (Thor).
+# Implementation of the `licensee diff` command.
 class LicenseeCLI < Thor
   desc 'diff [PATH]', 'Compare the given license text to a known license'
   option :license, type: :string, desc: 'The SPDX ID or key of the license to compare'

--- a/lib/licensee/commands/license_path.rb
+++ b/lib/licensee/commands/license_path.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# `licensee license-path` command implementation (Thor).
+# `licensee license-path` command implementation.
 class LicenseeCLI < Thor
   desc 'license-path [PATH]', "Returns the path to the given project's license file"
   def license_path(path)

--- a/lib/licensee/commands/license_path.rb
+++ b/lib/licensee/commands/license_path.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# `licensee license-path` command implementation (Thor).
 class LicenseeCLI < Thor
   desc 'license-path [PATH]', "Returns the path to the given project's license file"
   def license_path(path)

--- a/lib/licensee/commands/version.rb
+++ b/lib/licensee/commands/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# `licensee version` command implementation (Thor).
 class LicenseeCLI < Thor
   desc 'version', 'Return the Licensee version'
   def version

--- a/lib/licensee/commands/version.rb
+++ b/lib/licensee/commands/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# `licensee version` command implementation (Thor).
+# `licensee version` command implementation.
 class LicenseeCLI < Thor
   desc 'version', 'Return the Licensee version'
   def version

--- a/lib/licensee/content_helper.rb
+++ b/lib/licensee/content_helper.rb
@@ -6,6 +6,7 @@ require_relative 'content_helper/normalization_methods'
 require_relative 'content_helper/similarity_methods'
 
 module Licensee
+  # Text normalization, hashing, wrapping, and similarity helpers for license content.
   module ContentHelper
     include Constants
     include NormalizationMethods

--- a/lib/licensee/content_helper/normalization_methods.rb
+++ b/lib/licensee/content_helper/normalization_methods.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module ContentHelper
+    # Mixin providing content normalization and stripping routines.
     module NormalizationMethods
       # Content with the title and version removed
       # The first time should normally be the attribution line

--- a/lib/licensee/content_helper/similarity_methods.rb
+++ b/lib/licensee/content_helper/similarity_methods.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module ContentHelper
+    # Mixin providing wordset-based similarity scoring.
     module SimilarityMethods
       # Given another license or project file, calculates the similarity
       # as a percentage of words in common, minus a tiny penalty that

--- a/lib/licensee/hash_helper.rb
+++ b/lib/licensee/hash_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Licensee
+  # Mixin that provides a `to_h` based on a class's `HASH_METHODS`.
   module HashHelper
     def to_h
       hash = {}

--- a/lib/licensee/license.rb
+++ b/lib/licensee/license.rb
@@ -9,6 +9,7 @@ require_relative 'license/identity_methods'
 module Licensee
   class InvalidLicense < ArgumentError; end
 
+  # Helpers used by `Licensee::License.all` for option normalization and filtering.
   module LicenseAllHelper
     module_function
 
@@ -31,6 +32,7 @@ module Licensee
     end
   end
 
+  # Represents a known license (metadata + normalized content) from vendored data.
   class License
     @all = {}
     @keys_licenses = {}

--- a/lib/licensee/license/class_methods.rb
+++ b/lib/licensee/license/class_methods.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   class License
+    # Class-level lookup and caching for licenses.
     module ClassMethods
       # All license objects defined via Licensee (via choosealicense.com)
       #

--- a/lib/licensee/license/content_methods.rb
+++ b/lib/licensee/license/content_methods.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   class License
+    # Instance methods for loading and working with license content.
     module ContentMethods
       # Path to vendored license file on disk
       def path

--- a/lib/licensee/license/identity_methods.rb
+++ b/lib/licensee/license/identity_methods.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   class License
+    # Instance methods for license identity (SPDX ID, name, title matching).
     module IdentityMethods
       SOURCE_PREFIX = %r{https?://(?:www\.)?}i
       SOURCE_SUFFIX = %r{(?:\.html?|\.txt|/)(?:\?[^\s]*)?}i

--- a/lib/licensee/license_field.rb
+++ b/lib/licensee/license_field.rb
@@ -3,6 +3,7 @@
 module Licensee
   LicenseField = Struct.new(:name, :description)
 
+  # Represents a templated field placeholder used in license text.
   class LicenseField
     class << self
       # Return a single license field

--- a/lib/licensee/license_meta.rb
+++ b/lib/licensee/license_meta.rb
@@ -6,6 +6,7 @@ module Licensee
     :limitations, :using, :featured, :hidden, :nickname, :note
   )
 
+  # Structured license metadata loaded from vendored YAML front matter.
   class LicenseMeta
     # These should be in sync with choosealicense.com's collection defaults
     DEFAULTS = {

--- a/lib/licensee/license_rules.rb
+++ b/lib/licensee/license_rules.rb
@@ -4,6 +4,7 @@ module Licensee
   # Exposes #conditions, #permissions, and #limitation arrays of LicenseRules
   LicenseRules = Struct.new(:conditions, :permissions, :limitations)
 
+  # Normalizes rule tags from metadata into `Licensee::Rule` objects.
   class LicenseRules
     include Licensee::HashHelper
 

--- a/lib/licensee/matchers.rb
+++ b/lib/licensee/matchers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Licensee
+  # Matchers for detecting licenses from project file content.
   module Matchers
     autoload :Matcher,   'licensee/matchers/matcher'
     autoload :Cabal,     'licensee/matchers/cabal'

--- a/lib/licensee/matchers/cabal.rb
+++ b/lib/licensee/matchers/cabal.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Matches license identifiers in Cabal package files.
     class Cabal < Licensee::Matchers::Package
       # While we could parse the cabal file, prefer
       # a lenient regex for speed and security. Moar parsing moar problems.

--- a/lib/licensee/matchers/cargo.rb
+++ b/lib/licensee/matchers/cargo.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Matches license identifiers in Cargo.toml.
     class Cargo < Licensee::Matchers::Package
       LICENSE_REGEX = %r{
         ^\s*['"]?license['"]?\s*=\s*['"]([a-z\-0-9. +()/]+)['"]\s*

--- a/lib/licensee/matchers/copyright.rb
+++ b/lib/licensee/matchers/copyright.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Detects explicit copyright / reserved-rights notices.
     class Copyright < Licensee::Matchers::Matcher
       attr_reader :file
 

--- a/lib/licensee/matchers/cran.rb
+++ b/lib/licensee/matchers/cran.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Matches license identifiers in R package DESCRIPTION files.
     class Cran < Licensee::Matchers::Package
       attr_reader :file
 

--- a/lib/licensee/matchers/dice.rb
+++ b/lib/licensee/matchers/dice.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Similarity matcher based on the Dice coefficient over wordsets.
     class Dice < Licensee::Matchers::Matcher
       # Return the first potential license that is more similar
       # than the confidence threshold

--- a/lib/licensee/matchers/dist_zilla.rb
+++ b/lib/licensee/matchers/dist_zilla.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Matches license identifiers in Dist::Zilla dist.ini files.
     class DistZilla < Licensee::Matchers::Package
       attr_reader :file
 

--- a/lib/licensee/matchers/exact.rb
+++ b/lib/licensee/matchers/exact.rb
@@ -2,7 +2,8 @@
 
 module Licensee
   module Matchers
-    # Exact matcher for identical normalized wordsets.
+    # Exact matcher that succeeds when the license file's normalized wordset
+    # exactly matches a known license's normalized wordset.
     class Exact < Licensee::Matchers::Matcher
       def match
         return @match if defined? @match

--- a/lib/licensee/matchers/exact.rb
+++ b/lib/licensee/matchers/exact.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Exact matcher for identical normalized wordsets.
     class Exact < Licensee::Matchers::Matcher
       def match
         return @match if defined? @match

--- a/lib/licensee/matchers/gemspec.rb
+++ b/lib/licensee/matchers/gemspec.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Matches license identifiers in RubyGems .gemspec files.
     class Gemspec < Licensee::Matchers::Package
       # a value is a string surrounded by any amount of whitespace
       # optionally ended with (non-captured) ".freeze"

--- a/lib/licensee/matchers/matcher.rb
+++ b/lib/licensee/matchers/matcher.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Base class for matchers that identify a license from a ProjectFile.
     class Matcher
       attr_reader :file
 

--- a/lib/licensee/matchers/npm_bower.rb
+++ b/lib/licensee/matchers/npm_bower.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Matches license identifiers in package.json / bower.json files.
     class NpmBower < Licensee::Matchers::Package
       # While we could parse the package.json or bower.json file, prefer
       # a lenient regex for speed and security. Moar parsing moar problems.

--- a/lib/licensee/matchers/nuget.rb
+++ b/lib/licensee/matchers/nuget.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Matches license identifiers in NuGet .nuspec files.
     class NuGet < Licensee::Matchers::Package
       # While we could parse the nuspec file, prefer a lenient regex for speed and security.
       # Moar parsing moar problems.

--- a/lib/licensee/matchers/package.rb
+++ b/lib/licensee/matchers/package.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Base matcher for package manager metadata files declaring a license.
     class Package < Licensee::Matchers::Matcher
       def match
         return @match if defined? @match

--- a/lib/licensee/matchers/spdx.rb
+++ b/lib/licensee/matchers/spdx.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module Matchers
+    # Matches SPDX-declared package license identifiers in LICENSE.spdx files.
     class Spdx < Licensee::Matchers::Package
       # While we could parse the LICENSE.spdx file, prefer
       # a lenient regex for speed and security. Moar parsing moar problems.

--- a/lib/licensee/project_files.rb
+++ b/lib/licensee/project_files.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Licensee
+  # Project file types that can carry license information.
   module ProjectFiles
     autoload :ProjectFile, 'licensee/project_files/project_file'
     autoload :LicenseFile, 'licensee/project_files/license_file'

--- a/lib/licensee/project_files/license_file.rb
+++ b/lib/licensee/project_files/license_file.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module ProjectFiles
+    # A project file that contains the license text (e.g., LICENSE, COPYING).
     class LicenseFile < Licensee::ProjectFiles::ProjectFile
       include Licensee::ContentHelper
 

--- a/lib/licensee/project_files/package_manager_file.rb
+++ b/lib/licensee/project_files/package_manager_file.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module ProjectFiles
+    # A package manifest file that may declare a license identifier.
     class PackageManagerFile < Licensee::ProjectFiles::ProjectFile
       # Hash of Extension => [possible matchers]
       MATCHERS_EXTENSIONS = {

--- a/lib/licensee/project_files/project_file.rb
+++ b/lib/licensee/project_files/project_file.rb
@@ -6,6 +6,7 @@
 # Sublcasses should implement the possible_matchers method
 module Licensee
   module ProjectFiles
+    # Base class for a file within a project that may contain license information.
     class ProjectFile
       extend Forwardable
 

--- a/lib/licensee/project_files/readme_file.rb
+++ b/lib/licensee/project_files/readme_file.rb
@@ -2,6 +2,7 @@
 
 module Licensee
   module ProjectFiles
+    # A README file that may embed a license section.
     class ReadmeFile < Licensee::ProjectFiles::LicenseFile
       EXTENSIONS = %w[md markdown mdown txt rdoc rst].freeze
       SCORES = {

--- a/lib/licensee/projects.rb
+++ b/lib/licensee/projects.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Licensee
+  # Project scanners (filesystem/git/github) that expose license-related files.
   module Projects
     autoload :Project, 'licensee/projects/project'
     autoload :FSProject, 'licensee/projects/fs_project'

--- a/lib/licensee/projects/fs_project.rb
+++ b/lib/licensee/projects/fs_project.rb
@@ -9,6 +9,7 @@
 #  :dir  - the directory path containing the file
 module Licensee
   module Projects
+    # Scans a local directory for license-related files.
     class FSProject < Licensee::Projects::Project
       def initialize(path, **args)
         if ::File.file?(path)

--- a/lib/licensee/projects/git_project.rb
+++ b/lib/licensee/projects/git_project.rb
@@ -12,6 +12,7 @@ autoload :Rugged, 'rugged'
 
 module Licensee
   module Projects
+    # Scans a Git repository (via Rugged) for license-related files.
     class GitProject < Licensee::Projects::Project
       attr_reader :revision
 

--- a/lib/licensee/projects/github_project.rb
+++ b/lib/licensee/projects/github_project.rb
@@ -11,6 +11,7 @@ autoload :Octokit, 'octokit'
 
 module Licensee
   module Projects
+    # Scans a remote GitHub repository for license-related files (via API).
     class GitHubProject < Licensee::Projects::Project
       attr_reader :ref, :repo
 

--- a/lib/licensee/projects/project.rb
+++ b/lib/licensee/projects/project.rb
@@ -7,6 +7,7 @@
 # Subclasses must implement the Files and LoadFile private methods
 module Licensee
   module Projects
+    # Base class for project scanners (filesystem/git/github).
     class Project
       attr_reader :detect_readme, :detect_packages
       alias detect_readme? detect_readme

--- a/lib/licensee/rule.rb
+++ b/lib/licensee/rule.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Licensee
+  # A single rule used to describe license conditions/permissions/limitations.
   class Rule
     attr_reader :tag, :label, :description, :group
 


### PR DESCRIPTION
One brief, informative, non-useless doc comment for each module and class.