### PR TITLE
Only run Docker CI workflow on changes to Docker-related files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,14 @@ name: Docker
 on:
   push:
     branches: [main]
+    paths:
+      - Dockerfile
+      - .github/workflows/docker.yml
   pull_request:
     branches: [main]
+    paths:
+      - Dockerfile
+      - .github/workflows/docker.yml
 
 permissions:
   contents: read


### PR DESCRIPTION
It's the slowest test by far and doesn't exercise licensee code in any way that isn't covered by other tests.