### PR TITLE
exit code 0 when there is no license file; this is not an error

### DIFF
--- a/lib/licensee/commands/detect.rb
+++ b/lib/licensee/commands/detect.rb
@@ -145,7 +145,5 @@ class LicenseeCLI < Thor
     print_project_summary
     print_matched_files
     maybe_diff_license_file
-
-    exit !project.licenses.empty?
   end
 end

--- a/spec/licensee/commands/detect_spec.rb
+++ b/spec/licensee/commands/detect_spec.rb
@@ -145,8 +145,23 @@ RSpec.describe Licensee::Commands::Detect do
   context 'when there is no license match' do
     let(:arguments) { ["#{project_root}/spec/fixtures/wrk-modified-apache"] }
 
-    it 'Returns a one exit code' do
+    it 'Returns a zero exit code' do
       expect(status.exitstatus).to be(0)
+    end
+  end
+
+  context 'when directory is empty' do
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:arguments) { [tmpdir] }
+
+    after { FileUtils.rm_rf(tmpdir) }
+
+    it 'Returns a zero exit code' do
+      expect(status.exitstatus).to be(0)
+    end
+
+    it 'returns empty matches' do
+      expect(parsed_output).to eql({ 'License' => 'None' })
     end
   end
 end


### PR DESCRIPTION
Fixes #576