### PR TITLE
Make rugged an optional dependency

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,22 @@ On Windows, the last line needs to include the Ruby interpreter:
 
     bundle exec ruby bin\licensee
 
+### Git repository scanning (optional)
+
+By default, licensee scans projects using the filesystem. If you want to scan bare Git repositories or repositories without a working tree (e.g., on a Git server), install the [rugged](https://github.com/libgit2/rugged) gem, which provides Ruby bindings for libgit2:
+
+    gem install rugged
+
+Or add it to your `Gemfile` alongside licensee:
+
+```ruby
+gem 'rugged'
+```
+
+When rugged is available, `Licensee.project` will use it automatically. If rugged is not installed, licensee falls back to filesystem-based scanning transparently.
+
+Note that rugged is a native extension and requires `cmake` and `openssl` to build. On most systems these are available via a package manager (e.g., `apt install cmake libssl-dev` or `brew install cmake openssl`).
+
 ## Docker
 
 Licensee also comes with a Dockerfile if you prefer to run Licensee within a Docker container:

--- a/lib/licensee/projects/git_project.rb
+++ b/lib/licensee/projects/git_project.rb
@@ -8,7 +8,11 @@
 #  :name - the file's path relative to the repo root
 #  :oid  - the file's OID
 
-autoload :Rugged, 'rugged'
+begin
+  require 'rugged'
+rescue LoadError
+  # rugged is optional; GitProject will raise RuggedNotAvailable when not installed
+end
 
 module Licensee
   module Projects
@@ -17,8 +21,18 @@ module Licensee
       attr_reader :revision
 
       class InvalidRepository < ArgumentError; end
+      class RuggedNotAvailable < InvalidRepository; end
+
+      def self.available?
+        defined?(Rugged)
+      end
 
       def initialize(repo, revision: nil, **args)
+        unless self.class.available?
+          raise RuggedNotAvailable,
+                'Install the rugged gem to enable Git repository scanning'
+        end
+
         @raw_repo = repo
         @revision = revision
 

--- a/lib/licensee/projects/git_project.rb
+++ b/lib/licensee/projects/git_project.rb
@@ -24,7 +24,7 @@ module Licensee
       class RuggedNotAvailable < InvalidRepository; end
 
       def self.available?
-        defined?(Rugged)
+        !!defined?(Rugged)
       end
 
       def initialize(repo, revision: nil, **args)

--- a/licensee.gemspec
+++ b/licensee.gemspec
@@ -17,6 +17,11 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/licensee/licensee'
   gem.license  = 'MIT'
   gem.metadata['rubygems_mfa_required'] = 'true'
+  gem.post_install_message = <<~MSG
+    NOTE: The rugged gem is no longer a required dependency of licensee.
+    If you scan bare Git repositories or Git repos without a working tree,
+    add rugged to your Gemfile or run: gem install rugged
+  MSG
 
   gem.bindir = 'bin'
   gem.executables << 'licensee'
@@ -24,7 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency('dotenv', '>= 2', '< 4')
   gem.add_dependency('octokit', '>= 4.20', '< 11.0')
   gem.add_dependency('reverse_markdown', '>= 1', '< 4')
-  gem.add_dependency('rugged', '>= 0.24', '<2.0')
   gem.add_dependency('thor', '>= 0.19', '< 2.0')
 
   gem.add_development_dependency('gem-release', '~> 2.0')
@@ -34,6 +38,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rubocop', '~> 1.0')
   gem.add_development_dependency('rubocop-performance', '~> 1.5')
   gem.add_development_dependency('rubocop-rspec', '~> 3.0')
+  gem.add_development_dependency('rugged', '>= 0.24', '<2.0')
   gem.add_development_dependency('simplecov', '~> 0.16')
   gem.add_development_dependency('webmock', '~> 3.1')
 

--- a/spec/licensee/projects/git_project_spec.rb
+++ b/spec/licensee/projects/git_project_spec.rb
@@ -3,6 +3,28 @@
 RSpec.describe Licensee::Projects::GitProject do
   let(:fixture) { 'mit' }
 
+  describe '.available?' do
+    it 'returns true when rugged is installed' do
+      expect(described_class.available?).to be(true)
+    end
+  end
+
+  context 'when rugged is not available' do
+    before { allow(described_class).to receive(:available?).and_return(false) }
+
+    it 'raises RuggedNotAvailable' do
+      expect { described_class.new(fixture_path(fixture)) }.to raise_error(
+        Licensee::Projects::GitProject::RuggedNotAvailable
+      )
+    end
+
+    it 'RuggedNotAvailable is a kind of InvalidRepository' do
+      expect(Licensee::Projects::GitProject::RuggedNotAvailable.ancestors).to include(
+        Licensee::Projects::GitProject::InvalidRepository
+      )
+    end
+  end
+
   context 'when a new git repo is handled as a file system project' do
     let(:path) { fixture_path(fixture) }
 


### PR DESCRIPTION
rugged is a native extension that requires cmake and openssl to build, which can be painful on some platforms. Since filesystem-based scanning covers the common case, move rugged to a development dependency and fall back to FSProject transparently when it is not installed.

Users who scan bare Git repositories or repos without a working tree can opt in by adding rugged to their Gemfile or running gem install rugged.

Fixes #66