### PR TITLE
Add inactive thread locking workflow

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,37 @@
+name: Lock inactive closed threads
+
+on:
+  schedule:
+    - cron: '23 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  lock-threads:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Lock inactive closed threads
+        uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6
+        with:
+          issue-inactive-days: '90'
+          issue-comment: ''
+          issue-lock-reason: resolved
+          add-issue-labels: ''
+          remove-issue-labels: ''
+          pr-inactive-days: '30'
+          pr-comment: ''
+          pr-lock-reason: resolved
+          add-pr-labels: ''
+          remove-pr-labels: ''
+          process-only: "issues, prs"


### PR DESCRIPTION
## Summary

- lock closed issues after 90 days of inactivity
- lock closed or merged pull requests after 30 days of inactivity
- run weekly at a non-round UTC minute, with a manual `workflow_dispatch` trigger

The action only searches for `is:closed` threads, so open issues and pull requests are unaffected. Locked threads use the `resolved` reason, and maintainers retain the ability to comment on them. The workflow does not post automatic comments or modify labels.